### PR TITLE
Replace usages of 'fby' with '++'.

### DIFF
--- a/src/main/scala/scalaz/stream/Exchange.scala
+++ b/src/main/scala/scalaz/stream/Exchange.scala
@@ -125,13 +125,13 @@ final case class Exchange[I, W](read: Process[Task, I], write: Sink[Task, W]) {
     val wq = async.boundedQueue[W](0)
     val w2q = async.boundedQueue[W2](0)
 
-    def cleanup: Process[Task, Nothing] = eval_(wq.close) fby eval_(w2q.close)
+    def cleanup: Process[Task, Nothing] = eval_(wq.close) ++ eval_(w2q.close)
     def receive: Process[Task, I] = self.read onComplete cleanup
     def send: Process[Task, Unit] = wq.dequeue to self.write
 
     def sendAndReceive = {
       val (o, ny) = y.unemit
-      (emitAll(o) fby ((wq.size.discrete either receive).wye(w2q.dequeue)(ny)(S) onComplete cleanup) either send).flatMap {
+      (emitAll(o) ++ ((wq.size.discrete either receive).wye(w2q.dequeue)(ny)(S) onComplete cleanup) either send).flatMap {
         case \/-(o) => halt
         case -\/(-\/(o)) => eval_(wq.enqueueOne(o))
         case -\/(\/-(b)) => emit(b)
@@ -159,10 +159,10 @@ final case class Exchange[I, W](read: Process[Task, I], write: Sink[Task, W]) {
           case ReceiveL(-\/(_)) => go(cur)
           case ReceiveL(\/-(i)) =>
             cur.feed1(i).unemit match {
-              case (out,hlt@Halt(rsn)) => emitAll(out) fby hlt
-              case (out,next) => emitAll(out) fby go(next)
+              case (out,hlt@Halt(rsn)) => emitAll(out) ++ hlt
+              case (out,next) => emitAll(out) ++ go(next)
             }
-          case ReceiveR(w) => tell(w) fby go(cur)
+          case ReceiveR(w) => tell(w) ++ go(cur)
           case HaltL(rsn) => Halt(rsn)
           case HaltR(rsn) => go(cur)
         }
@@ -196,8 +196,8 @@ object Exchange {
     def loop(cur: Process1[W, I]): WyeW[Nothing, Nothing, W, I] = {
       awaitR[W] flatMap {
         case w => cur.feed1(w).unemit match {
-          case (o, hlt@Halt(rsn)) => emitAll(o.map(right)) fby hlt
-          case (o, np)            => emitAll(o.map(right)) fby loop(np)
+          case (o, hlt@Halt(rsn)) => emitAll(o.map(right)) ++ hlt
+          case (o, np)            => emitAll(o.map(right)) ++ loop(np)
         }
       }
     }
@@ -207,7 +207,7 @@ object Exchange {
     })({ q =>
       val (out, np) = p.unemit
       val ex = Exchange[Nothing, W](halt, q.enqueue)
-      emit(ex.wye(emitAll(out).map(right) fby loop(np))) onComplete eval_(q.close)
+      emit(ex.wye(emitAll(out).map(right) ++ loop(np))) onComplete eval_(q.close)
     })
 
   }

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -842,8 +842,8 @@ object Process extends ProcessInstances {
    */
   def constant[A](a: A, chunkSize: Int = 1): Process0[A] = {
     lazy val go: Process0[A] =
-      if (chunkSize.max(1) == 1) emit(a) fby go
-      else emitAll(List.fill(chunkSize)(a)) fby go
+      if (chunkSize.max(1) == 1) emit(a) ++ go
+      else emitAll(List.fill(chunkSize)(a)) ++ go
     go
   }
 

--- a/src/main/scala/scalaz/stream/async/mutable/Signal.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Signal.scala
@@ -116,11 +116,11 @@ object Signal {
   protected[async] def signalWriter[A]: Writer1[A,Msg[A],Nothing] = {
     def go(oa:Option[A]) : Writer1[A,Msg[A],Nothing] =
     receive1[Msg[A], A \/ Nothing] {
-      case Set(a) => tell(a) fby go(Some(a))
+      case Set(a) => tell(a) ++ go(Some(a))
       case CompareAndSet(f:(Option[A] => Option[A])@unchecked) =>
         val next = f(oa)
         next match {
-          case Some(a) => tell(a) fby go(Some(a))
+          case Some(a) => tell(a) ++ go(Some(a))
           case None => go(oa)
         }
     }

--- a/src/main/scala/scalaz/stream/compress.scala
+++ b/src/main/scala/scalaz/stream/compress.scala
@@ -40,7 +40,7 @@ object compress {
       receive1 { bytes =>
         deflater.setInput(bytes.toArray)
         val chunks = collect(deflater, buf, Deflater.NO_FLUSH)
-        emitAll(chunks) fby go(deflater, buf)
+        emitAll(chunks) ++ go(deflater, buf)
       }
 
     def flush(deflater: Deflater, buf: Array[Byte]): Process0[ByteVector] =
@@ -76,7 +76,7 @@ object compress {
       receive1 { bytes =>
         inflater.setInput(bytes.toArray)
         val chunks = collect(inflater, buf, Vector.empty)
-        emitAll(chunks) fby go(inflater, buf)
+        emitAll(chunks) ++ go(inflater, buf)
       }
 
     suspend {

--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -190,7 +190,7 @@ package object nondeterminism {
       })
 
 
-      (eval_(start) fby q.dequeue)
+      (eval_(start) ++ q.dequeue)
       .onComplete(eval_(Task.async[Unit] { cb => actor ! FinishedDown(cb) }))
     }
 

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -46,7 +46,7 @@ object process1 {
   def chunk[I](n: Int): Process1[I, Vector[I]] = {
     require(n > 0, "chunk size must be > 0, was: " + n)
     def go(m: Int, acc: Vector[I]): Process1[I, Vector[I]] =
-      if (m <= 0) emit(acc) fby go(n, Vector())
+      if (m <= 0) emit(acc) ++ go(n, Vector())
       else receive1Or[I, Vector[I]](if (acc.nonEmpty) emit(acc) else halt) { i =>
         go(m - 1, acc :+ i)
       }
@@ -70,7 +70,7 @@ object process1 {
       receive1Or[I,Vector[I]](emit(acc)) { i =>
         val chunk = acc :+ i
         val cur = f(i)
-        if (!cur && last) emit(chunk) fby go(Vector(), false)
+        if (!cur && last) emit(chunk) ++ go(Vector(), false)
         else go(chunk, cur)
       }
     go(Vector(), false)
@@ -83,7 +83,7 @@ object process1 {
     def go(acc: Vector[I], last: I): Process1[I, Vector[I]] =
       receive1Or[I,Vector[I]](emit(acc)) { i =>
         if (f(last, i)) go(acc :+ i, i)
-        else emit(acc) fby go(Vector(i), i)
+        else emit(acc) ++ go(Vector(i), i)
       }
     receive1(i => go(Vector(i), i))
   }
@@ -115,7 +115,7 @@ object process1 {
    * }}}
    */
   def delete[I](f: I => Boolean): Process1[I, I] =
-    receive1(i => if (f(i)) id else emit(i) fby delete(f))
+    receive1(i => if (f(i)) id else emit(i) ++ delete(f))
 
   /**
    * Remove any leading emitted values that occur before the first successful
@@ -153,7 +153,7 @@ object process1 {
   /** Skips the first `n` elements of the input, then passes through the rest. */
   def drop[I](n: Int): Process1[I, I] =
     if (n <= 0) id
-    else skip fby drop(n - 1)
+    else skip ++ drop(n - 1)
 
   /** Emits all but the last element of the input. */
   def dropLast[I]: Process1[I, I] =
@@ -163,7 +163,7 @@ object process1 {
   def dropLastIf[I](p: I => Boolean): Process1[I, I] = {
     def go(prev: I): Process1[I, I] =
       receive1Or[I,I](if (p(prev)) halt else emit(prev)) { i =>
-        emit(prev) fby go(i)
+        emit(prev) ++ go(i)
       }
     receive1(go)
   }
@@ -171,7 +171,7 @@ object process1 {
   /** Emits all but the last `n` elements of the input. */
   def dropRight[I](n: Int): Process1[I, I] = {
     def go(acc: Vector[I]): Process1[I, I] =
-      receive1(i => emit(acc.head) fby go(acc.tail :+ i))
+      receive1(i => emit(acc.head) ++ go(acc.tail :+ i))
     if (n <= 0) id
     else chunk(n).once.flatMap(go)
   }
@@ -181,7 +181,7 @@ object process1 {
    * then passes through the remaining inputs.
    */
   def dropWhile[I](f: I => Boolean): Process1[I, I] =
-    receive1(i => if (f(i)) dropWhile(f) else emit(i) fby id)
+    receive1(i => if (f(i)) dropWhile(f) else emit(i) ++ id)
 
   /** Feed a single input to a `Process1`. */
   def feed1[I, O](i: I)(p: Process1[I, O]): Process1[I, O] =
@@ -217,7 +217,7 @@ object process1 {
    */
   def filterBy2[I](f: (I, I) => Boolean): Process1[I, I] = {
     def pass(i: I): Process1[I, I] =
-      emit(i) fby go(f(i, _))
+      emit(i) ++ go(f(i, _))
     def go(g: I => Boolean): Process1[I, I] =
       receive1(i => if (g(i)) pass(i) else go(g))
     receive1(pass)
@@ -302,7 +302,7 @@ object process1 {
    * }}}
    */
   def intersperse[A](separator: A): Process1[A, A] =
-    await1[A] fby id[A].flatMap(a => Process(separator, a))
+    await1[A] ++ id[A].flatMap(a => Process(separator, a))
 
   /** Skips all but the last element of the input. */
   def last[I]: Process1[I, I] = {
@@ -334,10 +334,10 @@ object process1 {
           val (bs, next) = curr.feed1(a).unemit
           val out =  emitAll(bs).map(-\/(_))
           next match {
-            case Halt(rsn) => out fby Halt(rsn)
-            case other => out fby go(other)
+            case Halt(rsn) => out ++ Halt(rsn)
+            case other => out ++ go(other)
           }
-        case \/-(c) => emitO(c) fby go(curr)
+        case \/-(c) => emitO(c) ++ go(curr)
       }
     }
     go(p)
@@ -475,7 +475,7 @@ object process1 {
         parts.size match {
           case 0 => go(None)
           case 1 => go(Some(parts.head))
-          case _ => emitAll(parts.init) fby go(Some(parts.last))
+          case _ => emitAll(parts.init) ++ go(Some(parts.last))
         }
       }
     go(None)
@@ -493,7 +493,7 @@ object process1 {
       receive1Or[I,I](emitAll(carry.toList)) { i =>
         val next = carry.fold(i)(c => I.append(c, i))
         val (fst, snd) = p(next)
-        fst.fold(go(snd))(head => emit(head) fby go(snd))
+        fst.fold(go(snd))(head => emit(head) ++ go(snd))
       }
     go(None)
   }
@@ -511,7 +511,7 @@ object process1 {
    * It will always emit `z`, even when the Process of `A` is empty
    */
   def scan[A, B](z: B)(f: (B, A) => B): Process1[A, B] =
-    emit(z) fby receive1(a => scan(f(z, a))(f))
+    emit(z) ++ receive1(a => scan(f(z, a))(f))
 
   /**
    * Similar to `scan`, but unlike it it won't emit the `z` even when there is no input of `A`.
@@ -565,7 +565,7 @@ object process1 {
    * }}}
    */
   def shiftRight[I](head: I*): Process1[I, I] =
-    emitAll(head) fby id
+    emitAll(head) ++ id
 
   /**
    * Reads a single element of the input, emits nothing, then halts.
@@ -593,7 +593,7 @@ object process1 {
   def sliding[I](n: Int): Process1[I, Vector[I]] = {
     require(n > 0, "window size must be > 0, was: " + n)
     def go(window: Vector[I]): Process1[I, Vector[I]] =
-      emit(window) fby receive1(i => go(window.tail :+ i))
+      emit(window) ++ receive1(i => go(window.tail :+ i))
     chunk(n).once.flatMap(go)
   }
 
@@ -605,7 +605,7 @@ object process1 {
   def split[I](f: I => Boolean): Process1[I, Vector[I]] = {
     def go(acc: Vector[I]): Process1[I, Vector[I]] =
       receive1Or[I, Vector[I]](emit(acc)) { i =>
-        if (f(i)) emit(acc) fby go(Vector())
+        if (f(i)) emit(acc) ++ go(Vector())
         else go(acc :+ i)
       }
     go(Vector())
@@ -633,7 +633,7 @@ object process1 {
       receive1Or[I, Vector[I]](emit(acc)) { i =>
          val cur = f(i)
          if (cur == last) go(acc :+ i, cur)
-         else emit(acc) fby go(Vector(i), cur)
+         else emit(acc) ++ go(Vector(i), cur)
       }
     receive1(i => go(Vector(i), f(i)))
   }
@@ -659,7 +659,7 @@ object process1 {
   /** Passes through `n` elements of the input, then halts. */
   def take[I](n: Int): Process1[I, I] =
     if (n <= 0) halt
-    else await1[I] fby take(n - 1)
+    else await1[I] ++ take(n - 1)
 
   /** Emits the last `n` elements of the input. */
   def takeRight[I](n: Int): Process1[I, I] = {
@@ -671,11 +671,11 @@ object process1 {
 
   /** Passes through elements of the input as long as the predicate is true, then halts. */
   def takeWhile[I](f: I => Boolean): Process1[I, I] =
-    receive1 (i => if (f(i)) emit(i) fby takeWhile(f) else halt)
+    receive1 (i => if (f(i)) emit(i) ++ takeWhile(f) else halt)
 
   /** Like `takeWhile`, but emits the first value which tests false. */
   def takeThrough[I](f: I => Boolean): Process1[I, I] =
-    receive1 (i => if (f(i)) emit(i) fby takeThrough(f) else emit(i))
+    receive1 (i => if (f(i)) emit(i) ++ takeThrough(f) else emit(i))
 
   /** Wraps all inputs in `Some`, then outputs a single `None` before halting. */
   def terminated[A]: Process1[A, Option[A]] =
@@ -713,7 +713,7 @@ object process1 {
    */
   def zipWithNext[I]: Process1[I,(I,Option[I])] = {
     def go(prev: I): Process1[I,(I,Option[I])] =
-      receive1Or[I,(I,Option[I])](emit((prev, None)))(i => emit((prev, Some(i))) fby go(i))
+      receive1Or[I,(I,Option[I])](emit((prev, None)))(i => emit((prev, Some(i))) ++ go(i))
     receive1(go)
   }
 
@@ -756,12 +756,12 @@ object process1 {
   def zipWithScan1[A,B](z: B)(f: (A,B) => B): Process1[A,(A,B)] =
     receive1 { a =>
       val z2 = f(a,z)
-      emit((a,z2)) fby zipWithScan1(z2)(f)
+      emit((a,z2)) ++ zipWithScan1(z2)(f)
     }
 
   /** Zips the input with state that begins with `z` and is updated by `next`. */
   def zipWithState[A,B](z: B)(next: (A, B) => B): Process1[A,(A,B)] =
-    receive1(a => emit((a, z)) fby zipWithState(next(a, z))(next))
+    receive1(a => emit((a, z)) ++ zipWithState(next(a, z))(next))
 
   object Await1 {
     /** deconstruct for `Await` directive of `Process1` */

--- a/src/main/scala/scalaz/stream/tee.scala
+++ b/src/main/scala/scalaz/stream/tee.scala
@@ -47,11 +47,11 @@ object tee {
 
   /** Echoes the right branch until the left branch becomes `true`, then halts. */
   def until[I]: Tee[Boolean, I, I] =
-    awaitL[Boolean].flatMap(kill => if (kill) halt else awaitR[I] fby until)
+    awaitL[Boolean].flatMap(kill => if (kill) halt else awaitR[I] ++ until)
 
   /** Echoes the right branch when the left branch is `true`. */
   def when[I]: Tee[Boolean, I, I] =
-    awaitL[Boolean].flatMap(ok => if (ok) awaitR[I] fby when else when)
+    awaitL[Boolean].flatMap(ok => if (ok) awaitR[I] ++ when else when)
 
   /** Defined as `zipWith((_,_))` */
   def zip[I, I2]: Tee[I, I2, (I, I2)] = zipWith((_, _))

--- a/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
+++ b/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
@@ -89,7 +89,7 @@ object AsyncSignalSpec extends Properties("async.signal") {
       val signal = async.signal[(String, Int)]
 
       val closeSignal =
-        Process.sleep(100 millis) fby
+        Process.sleep(100 millis) ++
           (if (l.size % 2 == 0) Process.eval_(signal.close)
           else Process.eval_(signal.fail(Bwahahaa)))
 
@@ -176,7 +176,7 @@ object AsyncSignalSpec extends Properties("async.signal") {
   //tests that signal terminates when discrete process terminates
   property("from.discrete.terminates") = secure {
     val sleeper = Process.eval_{Task.delay(Thread.sleep(1000))}
-    val sig = async.toSignal[Int](sleeper fby Process(1,2,3,4).toSource,haltOnSource = true)
+    val sig = async.toSignal[Int](sleeper ++ Process(1,2,3,4).toSource,haltOnSource = true)
     val initial = sig.discrete.runLog.run
     val afterClosed = sig.discrete.runLog.run
     (initial == Vector(1,2,3,4)) && (afterClosed== Vector())
@@ -185,7 +185,7 @@ object AsyncSignalSpec extends Properties("async.signal") {
   //tests that signal terminates with failure when discrete process terminates with failure
   property("from.discrete.fail") = secure {
     val sleeper = Process.eval_{Task.delay(Thread.sleep(1000))}
-    val sig = async.toSignal[Int](sleeper fby Process(1,2,3,4).toSource fby Process.fail(Bwahahaa),haltOnSource = true)
+    val sig = async.toSignal[Int](sleeper ++ Process(1,2,3,4).toSource ++ Process.fail(Bwahahaa),haltOnSource = true)
     sig.discrete.runLog.attemptRun == -\/(Bwahahaa)
   }
 
@@ -193,7 +193,7 @@ object AsyncSignalSpec extends Properties("async.signal") {
   // process terminates with failure even when haltOnSource is set to false
   property("from.discrete.fail.always") = secure {
     val sleeper = Process.eval_{Task.delay(Thread.sleep(1000))}
-    val sig = async.toSignal[Int](sleeper fby Process(1,2,3,4).toSource fby Process.fail(Bwahahaa))
+    val sig = async.toSignal[Int](sleeper ++ Process(1,2,3,4).toSource ++ Process.fail(Bwahahaa))
     sig.discrete.runLog.attemptRun == -\/(Bwahahaa)
   }
 

--- a/src/test/scala/scalaz/stream/AsyncTopicSpec.scala
+++ b/src/test/scala/scalaz/stream/AsyncTopicSpec.scala
@@ -19,7 +19,7 @@ object WriterHelper {
       receive1[String, Long \/ Int] {
         s =>
           val t: Long = s.size.toLong + acc
-          emit(-\/(t)) fby emit(\/-(s.size)) fby go(t)
+          emit(-\/(t)) ++ emit(\/-(s.size)) ++ go(t)
       }
     }
     go(0)
@@ -120,7 +120,7 @@ object AsyncTopicSpec extends Properties("topic") {
     l: List[String] =>
       (l.nonEmpty) ==> {
 
-        val topic = async.writerTopic(emit(-\/(0L)) fby WriterHelper.w)()
+        val topic = async.writerTopic(emit(-\/(0L)) ++ WriterHelper.w)()
 
         val published = new SyncVar[Throwable \/ IndexedSeq[Long \/ Int]]
         topic.subscribe.runLog.runAsync(published.put)
@@ -155,7 +155,7 @@ object AsyncTopicSpec extends Properties("topic") {
   property("writer.state.startWith.up") = forAll {
     l: List[String] =>
       (l.nonEmpty) ==> {
-        val topic = async.writerTopic(emit(-\/(0L)) fby WriterHelper.w)()
+        val topic = async.writerTopic(emit(-\/(0L)) ++ WriterHelper.w)()
         ((Process(l: _*).toSource to topic.publish)).run.run
 
         val subscriber = topic.subscribe.take(1).runLog.run
@@ -165,7 +165,7 @@ object AsyncTopicSpec extends Properties("topic") {
   }
 
   property("writer.state.startWith.down") = secure {
-    val topic = async.writerTopic(emit(-\/(0L)) fby WriterHelper.w)()
+    val topic = async.writerTopic(emit(-\/(0L)) ++ WriterHelper.w)()
     val subscriber = topic.subscribe.take(1).runLog.run
     topic.close.run
     subscriber == List(-\/(0))

--- a/src/test/scala/scalaz/stream/ExchangeSpec.scala
+++ b/src/test/scala/scalaz/stream/ExchangeSpec.scala
@@ -20,7 +20,7 @@ object ExchangeSpec extends Properties("Exchange") {
 
   property("emitHead") = secure {
     val xs = 1 until 10
-    val l = Exchange.loopBack[Int, Int](emitAll(xs) fby process1.id)
+    val l = Exchange.loopBack[Int, Int](emitAll(xs) ++ process1.id)
     l.flatMap(_.run(emitAll(xs))).take(xs.size + xs.size / 2).runLog.run.toSeq == xs ++ xs.take(xs.size / 2)
   }
 

--- a/src/test/scala/scalaz/stream/MergeNSpec.scala
+++ b/src/test/scala/scalaz/stream/MergeNSpec.scala
@@ -126,8 +126,8 @@ object MergeNSpec extends Properties("mergeN") {
 
     val ps =
       emitAll(for (i <- 0 until count) yield {
-        eval_(incrementOpen) fby
-          Process.range(0,eachSize).flatMap(i=> emit(i) fby sleep5) onComplete
+        eval_(incrementOpen) ++
+          Process.range(0,eachSize).flatMap(i=> emit(i) ++ sleep5) onComplete
           eval_(decrementDone)
       }).toSource
 

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -95,8 +95,8 @@ object ProcessSpec extends Properties("Process") {
       val durationSinceLastTrue: Process1[BD, BD] = {
         def go(lastTrue: Duration): Process1[BD,BD] = {
           await1 flatMap { pair:(Boolean, Duration) => pair match {
-            case (true , d) => emit((true , d - lastTrue)) fby go(d)
-            case (false, d) => emit((false, d - lastTrue)) fby go(lastTrue)
+            case (true , d) => emit((true , d - lastTrue)) ++ go(d)
+            case (false, d) => emit((false, d - lastTrue)) ++ go(lastTrue)
           } }
         }
         go(0.seconds)

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -258,7 +258,7 @@ object WyeSpec extends  Properties("Wye"){
     val term1 = async.signal[Boolean]
     term1.set(false).run
 
-    val p1: Process[Task,Unit] = (Process.sleep(10.hours) fby emit(true)).wye(Process.sleep(10 hours))(wye.interrupt)
+    val p1: Process[Task,Unit] = (Process.sleep(10.hours) ++ emit(true)).wye(Process.sleep(10 hours))(wye.interrupt)
     val p2:Process[Task,Unit] = repeatEval(Task.now(true)).flatMap(_ => p1)
     val toRun =  term1.discrete.wye(p2)(wye.interrupt)
 


### PR DESCRIPTION
This is an attempt to make the library a tiny little bit easier internally by sticking to only one alias for `append` in its own sources. Currently `++` and `fby` are used equally frequent. Note that this PR does not touch the definition of `fby`.