### PR TITLE
Move time related processes into a separate module

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1,10 +1,8 @@
 package scalaz.stream
 
 import Cause._
-import java.util.concurrent.ScheduledExecutorService
 import scala.annotation.tailrec
 import scala.collection.SortedMap
-import scala.concurrent.duration._
 import scalaz.{Catchable, Functor, Monad, Monoid, Nondeterminism, \/, -\/, ~>}
 import scalaz.\/._
 import scalaz.concurrent.{Actor, Strategy, Task}
@@ -777,49 +775,6 @@ object Process extends ProcessInstances {
     liftW(Process.awaitBoth[I, I2])
 
   /**
-   * Discrete process that every `d` emits elapsed duration
-   * since the start time of stream consumption.
-   *
-   * For example: `awakeEvery(5 seconds)` will
-   * return (approximately) `5s, 10s, 20s`, and will lie dormant
-   * between emitted values.
-   *
-   * By default, this uses a shared `ScheduledExecutorService`
-   * for the timed events, and runs the consumer using the `pool` `Strategy`,
-   * to allow for the process to decide whether result shall be run on
-   * different thread pool, or with `Strategy.Sequential` on the
-   * same thread pool as the scheduler.
-   *
-   * @param d           Duration between emits of the resulting process
-   * @param S           Strategy to run the process
-   * @param scheduler   Scheduler used to schedule tasks
-   */
-  def awakeEvery(d: Duration)(
-    implicit S: Strategy,
-    scheduler: ScheduledExecutorService): Process[Task, Duration] = {
-    def metronomeAndSignal:(()=>Unit,async.mutable.Signal[Duration]) = {
-      val t0 = Duration(System.nanoTime, NANOSECONDS)
-      val signal = async.toSignal[Duration](Process.halt)(S)
-
-      val metronome = scheduler.scheduleAtFixedRate(
-        new Runnable { def run = {
-          val d = Duration(System.nanoTime, NANOSECONDS) - t0
-          signal.set(d).run
-        }},
-        d.toNanos,
-        d.toNanos,
-        NANOSECONDS
-      )
-      (()=>metronome.cancel(false), signal)
-    }
-
-    await(Task.delay(metronomeAndSignal))({
-      case (cm, signal) =>  signal.discrete onComplete eval_(signal.close.map(_=>cm()))
-    })
-  }
-
-
-  /**
    * The infinite `Process`, always emits `a`.
    * If for performance reasons it is good to emit `a` in chunks,
    * specify size of chunk by `chunkSize` parameter
@@ -831,16 +786,6 @@ object Process extends ProcessInstances {
     go
   }
 
-  /**
-   * A continuous stream of the elapsed time, computed using `System.nanoTime`.
-   * Note that the actual granularity of these elapsed times depends on the OS, for instance
-   * the OS may only update the current time every ten milliseconds or so.
-   */
-  def duration: Process[Task, FiniteDuration] =
-    eval(Task.delay(System.nanoTime)).flatMap { t0 =>
-      repeatEval(Task.delay(FiniteDuration(System.nanoTime - t0, NANOSECONDS)))
-    }
-
   /** A `Writer` which emits one value to the output. */
   def emitO[O](o: O): Process0[Nothing \/ O] =
     Process.emit(right(o))
@@ -848,22 +793,6 @@ object Process extends ProcessInstances {
   /** A `Writer` which writes the given value. */
   def emitW[W](s: W): Process0[W \/ Nothing] =
     Process.emit(left(s))
-
-  /**
-   * A 'continuous' stream which is true after `d, 2d, 3d...` elapsed duration,
-   * and false otherwise.
-   * If you'd like a 'discrete' stream that will actually block until `d` has elapsed,
-   * use `awakeEvery` instead.
-   */
-  def every(d: Duration): Process[Task, Boolean] = {
-    def go(lastSpikeNanos: Long): Process[Task, Boolean] =
-      suspend {
-        val now = System.nanoTime
-        if ((now - lastSpikeNanos) > d.toNanos) emit(true) ++ go(now)
-        else emit(false) ++ go(lastSpikeNanos)
-      }
-    go(0)
-  }
 
   /** A `Process` which emits `n` repetitions of `a`. */
   def fill[A](n: Int)(a: A, chunkSize: Int = 1): Process0[A] = {
@@ -934,19 +863,6 @@ object Process extends ProcessInstances {
           None
     }
   }
-
-  /**
-   * A single-element `Process` that waits for the duration `d`
-   * before emitting its value. This uses a shared
-   * `ScheduledThreadPoolExecutor` to signal duration and
-   * avoid blocking on thread. After the signal,
-   * the execution continues with `S` strategy
-   */
-  def sleep(d: FiniteDuration)(
-    implicit S: Strategy
-    , schedulerPool: ScheduledExecutorService
-    ): Process[Task, Nothing] =
-    awakeEvery(d).once.drain
 
   /**
    * Delay running `p` until `awaken` becomes true for the first time.

--- a/src/main/scala/scalaz/stream/time.scala
+++ b/src/main/scala/scalaz/stream/time.scala
@@ -1,0 +1,93 @@
+package scalaz.stream
+
+import java.util.concurrent.ScheduledExecutorService
+
+import scala.concurrent.duration._
+import scalaz.concurrent.{Strategy, Task}
+
+import Process._
+
+object time {
+
+  /**
+   * Discrete process that every `d` emits elapsed duration
+   * since the start time of stream consumption.
+   *
+   * For example: `awakeEvery(5 seconds)` will
+   * return (approximately) `5s, 10s, 20s`, and will lie dormant
+   * between emitted values.
+   *
+   * By default, this uses a shared `ScheduledExecutorService`
+   * for the timed events, and runs the consumer using the `pool` `Strategy`,
+   * to allow for the process to decide whether result shall be run on
+   * different thread pool, or with `Strategy.Sequential` on the
+   * same thread pool as the scheduler.
+   *
+   * @param d           Duration between emits of the resulting process
+   * @param S           Strategy to run the process
+   * @param scheduler   Scheduler used to schedule tasks
+   */
+  def awakeEvery(d: Duration)(
+    implicit S: Strategy,
+    scheduler: ScheduledExecutorService): Process[Task, Duration] = {
+    def metronomeAndSignal:(()=>Unit,async.mutable.Signal[Duration]) = {
+      val t0 = Duration(System.nanoTime, NANOSECONDS)
+      val signal = async.toSignal[Duration](Process.halt)(S)
+
+      val metronome = scheduler.scheduleAtFixedRate(
+        new Runnable { def run = {
+          val d = Duration(System.nanoTime, NANOSECONDS) - t0
+          signal.set(d).run
+        }},
+        d.toNanos,
+        d.toNanos,
+        NANOSECONDS
+      )
+      (()=>metronome.cancel(false), signal)
+    }
+
+    await(Task.delay(metronomeAndSignal))({
+      case (cm, signal) =>  signal.discrete onComplete eval_(signal.close.map(_=>cm()))
+    })
+  }
+
+  /**
+   * A continuous stream of the elapsed time, computed using `System.nanoTime`.
+   * Note that the actual granularity of these elapsed times depends on the OS, for instance
+   * the OS may only update the current time every ten milliseconds or so.
+   */
+  def duration: Process[Task, FiniteDuration] =
+    eval(Task.delay(System.nanoTime)).flatMap { t0 =>
+      repeatEval(Task.delay(FiniteDuration(System.nanoTime - t0, NANOSECONDS)))
+    }
+
+  /**
+   * A 'continuous' stream which is true after `d, 2d, 3d...` elapsed duration,
+   * and false otherwise.
+   * If you'd like a 'discrete' stream that will actually block until `d` has elapsed,
+   * use `awakeEvery` instead.
+   */
+  def every(d: Duration): Process[Task, Boolean] = {
+    def go(lastSpikeNanos: Long): Process[Task, Boolean] =
+      suspend {
+        val now = System.nanoTime
+        if ((now - lastSpikeNanos) > d.toNanos) emit(true) ++ go(now)
+        else emit(false) ++ go(lastSpikeNanos)
+      }
+    go(0)
+  }
+
+  /**
+   * A single-element `Process` that waits for the duration `d`
+   * before emitting its value. This uses a shared
+   * `ScheduledThreadPoolExecutor` to signal duration and
+   * avoid blocking on thread. After the signal,
+   * the execution continues with `S` strategy
+   */
+  def sleep(d: FiniteDuration)(
+    implicit S: Strategy
+    , schedulerPool: ScheduledExecutorService
+    ): Process[Task, Nothing] =
+    awakeEvery(d).once.drain
+
+}

--- a/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
+++ b/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
@@ -86,7 +86,7 @@ object AsyncSignalSpec extends Properties("async.signal") {
       val signal = async.signal[(String, Int)]
 
       val closeSignal =
-        Process.sleep(100 millis) ++
+        time.sleep(100 millis) ++
           (if (l.size % 2 == 0) Process.eval_(signal.close)
           else Process.eval_(signal.fail(Bwahahaa)))
 
@@ -196,13 +196,13 @@ object AsyncSignalSpec extends Properties("async.signal") {
 
   property("continuous") = secure {
     val sig = async.signal[Int]
-    Process.awakeEvery(100.millis)
+    time.awakeEvery(100.millis)
       .zip(Process.range(1, 13))
       .map(x => Signal.Set(x._2))
       .to(sig.sink)
       .run
       .runAsync(_ => ())
-    val res = Process.awakeEvery(500.millis)
+    val res = time.awakeEvery(500.millis)
       .zip(sig.continuous)
       .map(_._2)
       .take(6)

--- a/src/test/scala/scalaz/stream/ExchangeSpec.scala
+++ b/src/test/scala/scalaz/stream/ExchangeSpec.scala
@@ -66,19 +66,19 @@ object ExchangeSpec extends Properties("Exchange") {
 
   property("run.terminate.on.read") = secure {
     val ex = Exchange[Int,Int](Process.range(1,10),Process.constant(i => Task.now(())))
-    ex.run(Process.sleep(1 minute)).runLog.timed(3000).run == (1 until 10).toVector
+    ex.run(time.sleep(1 minute)).runLog.timed(3000).run == (1 until 10).toVector
   }
 
 
   property("run.terminate.on.write") = secure {
-    val ex = Exchange[Int,Int](Process.sleep(1 minute),Process.constant(i => Task.now(())))
+    val ex = Exchange[Int,Int](time.sleep(1 minute),Process.constant(i => Task.now(())))
     ex.run(Process.range(1,10), Request.R).runLog.timed(3000).run == Vector()
   }
 
   property("run.terminate.on.read.or.write") = secure {
     val exL = Exchange[Int,Int](Process.range(1,10),Process.constant(i => Task.now(())))
-    val exR = Exchange[Int,Int](Process.sleep(1 minute),Process.constant(i => Task.now(())))
-    ("left side terminated" |: exL.run(Process.sleep(1 minute), Request.Both).runLog.timed(3000).run == (1 until 10).toVector) &&
+    val exR = Exchange[Int,Int](time.sleep(1 minute),Process.constant(i => Task.now(())))
+    ("left side terminated" |: exL.run(time.sleep(1 minute), Request.Both).runLog.timed(3000).run == (1 until 10).toVector) &&
       ("right side terminated" |: exR.run(Process.range(1,10), Request.Both).runLog.timed(3000).run == Vector())
   }
 

--- a/src/test/scala/scalaz/stream/MergeNSpec.scala
+++ b/src/test/scala/scalaz/stream/MergeNSpec.scala
@@ -70,7 +70,7 @@ object MergeNSpec extends Properties("mergeN") {
 
 
     //this below is due the non-thread-safety of scala object, we must memoize this here
-    val delayEach10 =  Process.awakeEvery(10 seconds)
+    val delayEach10 = time.awakeEvery(10 seconds)
 
     def oneUp(index:Int) =
       (emit(index).toSource ++ delayEach10.map(_=>index))
@@ -123,7 +123,7 @@ object MergeNSpec extends Properties("mergeN") {
         case None => Some(0)
       })
 
-    val sleep5 = sleep(5 millis)
+    val sleep5 = time.sleep(5 millis)
 
     val ps =
       emitAll(for (i <- 0 until count) yield {

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -119,7 +119,7 @@ object QueueSpec extends Properties("queue") {
   // from the process that is running
   property("queue-swallow-killed") = secure {
     val q = async.boundedQueue[Int]()
-    val sleeper = Process.sleep(1 second)
+    val sleeper = time.sleep(1 second)
     val signalKill = Process(false).toSource ++ sleeper ++ Process(true)
 
     signalKill.wye(q.dequeue)(wye.interrupt).runLog.run

--- a/src/test/scala/scalaz/stream/TimeSpec.scala
+++ b/src/test/scala/scalaz/stream/TimeSpec.scala
@@ -1,0 +1,62 @@
+package scalaz.stream
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Gen, Properties}
+import scala.concurrent.duration._
+import scalaz.concurrent.Strategy
+
+import Process._
+import time._
+
+object TimeSpec extends Properties("time") {
+
+  implicit val S = Strategy.DefaultStrategy
+  implicit val scheduler = scalaz.stream.DefaultScheduler
+
+  property("awakeEvery") = secure {
+    time.awakeEvery(100 millis).map(_.toMillis/100).take(5).runLog.run == Vector(1,2,3,4,5)
+  }
+
+  property("duration") = secure {
+    val firstValueDiscrepancy = time.duration.once.runLast
+    val reasonableErrorInMillis = 200
+    val reasonableErrorInNanos = reasonableErrorInMillis * 1000000
+    def p = firstValueDiscrepancy.run.get.toNanos < reasonableErrorInNanos
+
+    val r1 = p :| "first duration is near zero on first run"
+    Thread.sleep(reasonableErrorInMillis)
+    val r2 = p :| "first duration is near zero on second run"
+
+    r1 && r2
+  }
+
+  val smallDelay = Gen.choose(10, 300) map {_.millis}
+
+  property("every") =
+    forAll(smallDelay) { delay: Duration =>
+      type BD = (Boolean, Duration)
+      val durationSinceLastTrue: Process1[BD, BD] = {
+        def go(lastTrue: Duration): Process1[BD,BD] = {
+          await1 flatMap { pair:(Boolean, Duration) => pair match {
+            case (true , d) => emit((true , d - lastTrue)) ++ go(d)
+            case (false, d) => emit((false, d - lastTrue)) ++ go(lastTrue)
+          } }
+        }
+        go(0.seconds)
+      }
+
+      val draws = (600.millis / delay) min 10 // don't take forever
+
+      val durationsSinceSpike = time.every(delay).
+        tee(time.duration)(tee zipWith {(a,b) => (a,b)}).
+        take(draws.toInt) |>
+        durationSinceLastTrue
+
+      val result = durationsSinceSpike.runLog.run.toList
+      val (head :: tail) = result
+
+      head._1 :| "every always emits true first" &&
+        tail.filter   (_._1).map(_._2).forall { _ >= delay } :| "true means the delay has passed" &&
+        tail.filterNot(_._1).map(_._2).forall { _ <= delay } :| "false means the delay has not passed"
+    }
+}

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -137,14 +137,14 @@ object WyeSpec extends  Properties("Wye"){
 
 
   property("either.continue-when-left-done") = secure {
-    val e = (Process.range(0, 20) either (awakeEvery(25 millis).take(20))).runLog.timed(5000).run
+    val e = (Process.range(0, 20) either (time.awakeEvery(25 millis).take(20))).runLog.timed(5000).run
     ("Both sides were emitted" |: (e.size == 40))  &&
       ("Left side terminated earlier" |: e.zipWithIndex.filter(_._1.isLeft).lastOption.exists(_._2 < 35))   &&
       ("Right side was last" |:  e.zipWithIndex.filter(_._1.isRight).lastOption.exists(_._2 == 39))
   }
 
   property("either.continue-when-right-done") = secure {
-    val e = ((awakeEvery(25 millis).take(20)) either Process.range(0, 20)).runLog.timed(5000).run
+    val e = ((time.awakeEvery(25 millis).take(20)) either Process.range(0, 20)).runLog.timed(5000).run
     ("Both sides were emitted" |: (e.size == 40)) &&
       ("Right side terminated earlier" |: e.zipWithIndex.filter(_._1.isRight).lastOption.exists(_._2 < 35))   &&
       ("Left side was last" |: e.zipWithIndex.filter(_._1.isLeft).lastOption.exists(_._2 == 39))
@@ -177,8 +177,8 @@ object WyeSpec extends  Properties("Wye"){
     val syncO = new SyncVar[Int]
 
     // Left process terminates earlier.
-    val l = Process.awakeEvery(10 millis) onComplete eval_(Task.delay{ Thread.sleep(500);syncL.put(100)})
-    val r = Process.awakeEvery(10 millis) onComplete eval_(Task.delay{ Thread.sleep(600);syncR.put(200)})
+    val l = time.awakeEvery(10 millis) onComplete eval_(Task.delay{ Thread.sleep(500);syncL.put(100)})
+    val r = time.awakeEvery(10 millis) onComplete eval_(Task.delay{ Thread.sleep(600);syncR.put(200)})
 
     val e = ((l either r).take(10) onComplete eval_(Task.delay(syncO.put(1000)))).runLog.timed(3000).run
 
@@ -257,7 +257,7 @@ object WyeSpec extends  Properties("Wye"){
     val sync = new SyncVar[Throwable \/ IndexedSeq[Unit]]
     val term1 = async.signalOf(false)
 
-    val p1: Process[Task,Unit] = (Process.sleep(10.hours) ++ emit(true)).wye(Process.sleep(10 hours))(wye.interrupt)
+    val p1: Process[Task,Unit] = (time.sleep(10.hours) ++ emit(true)).wye(time.sleep(10 hours))(wye.interrupt)
     val p2:Process[Task,Unit] = repeatEval(Task.now(true)).flatMap(_ => p1)
     val toRun =  term1.discrete.wye(p2)(wye.interrupt)
 


### PR DESCRIPTION
This PR moves every time related `Process` from the `Process` companion into a separate `time` module (as proposed in https://github.com/scalaz/scalaz-stream/pull/253#issuecomment-59678852).