### PR TITLE
Remove bufferAll from Process1Syntax.apply

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1254,7 +1254,7 @@ object Process extends ProcessInstances {
 
     /** Apply this `Process` to an `Iterable`. */
     def apply(input: Iterable[I]): IndexedSeq[O] =
-      Process(input.toSeq: _*).pipe(self.bufferAll).toIndexedSeq
+      Process(input.toSeq: _*).pipe(self).toIndexedSeq
 
     /**
      * Transform `self` to operate on the left hand side of an `\/`, passing


### PR DESCRIPTION
`bufferAll` in `Process1Syntax.apply` seems unnecessary to me. What is its purpose? Can we add a test that fails without it?