### PR TITLE
Semantics of Process.duration

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -846,10 +846,10 @@ object Process extends ProcessInstances {
    * Note that the actual granularity of these elapsed times depends on the OS, for instance
    * the OS may only update the current time every ten milliseconds or so.
    */
-  def duration: Process[Task, Duration] = suspend {
-    val t0 = System.nanoTime
-    repeatEval { Task.delay { Duration(System.nanoTime - t0, NANOSECONDS) }}
-  }
+  def duration: Process[Task, Duration] =
+    eval(Task.delay(System.nanoTime)).flatMap { t0 =>
+      repeatEval(Task.delay(Duration(System.nanoTime - t0, NANOSECONDS)))
+    }
 
   /** A `Writer` which emits one value to the output. */
   def emitO[O](o: O): Process0[Nothing \/ O] =


### PR DESCRIPTION
`Process.duration` does not wrap the first call to `System.nanoTime` in `Task.delay` so that this time is fixed as soon as one of the `run*` methods is called on this process. This means that running the resulting `Task` multiple times will always yield durations which use the same reference time:
```scala
scala> val t = Process.duration.once.runLog; println(t.run); Thread.sleep(1000); println(t.run)
Vector(62569 nanoseconds)
Vector(1000755454 nanoseconds)
```
This seems odd to me. I would have expected that the reference time is newly obtained on every `Task.run`.

This PR changes the behavior of `duration` to what I would have expected and adds a corresponding test that currently fails on master.