### PR TITLE
Fix deadlock when terminating bounded njoin/mergeN

### DIFF
--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -113,10 +113,11 @@ package object nondeterminism {
 
             //runs the process with a chance to interrupt it using signal `done`
             //interrupt is done via killing the done signal.
+            //enqueue action needs to be interruptible, otherwise the process will never halt
+            //if the outer process is terminated while the queue is full and an enqueue is pending
             //note that here we convert `Kill` to exception to distinguish form normal and
             //killed behaviour of upstream termination
-            done.discrete.wye(p)(wye.interrupt)
-            .to(q.enqueue)
+            done.discrete.wye(p.to(q.enqueue))(wye.interrupt)
             .onHalt{
               case Kill => Halt(Error(Terminated(Kill)))
               case cause => Halt(cause)

--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -117,7 +117,7 @@ package object nondeterminism {
             //if the outer process is terminated while the queue is full and an enqueue is pending
             //note that here we convert `Kill` to exception to distinguish form normal and
             //killed behaviour of upstream termination
-            done.discrete.wye(p.to(q.enqueue))(wye.interrupt)
+            done.discrete.wye(p.flatMap(a => eval_(q.enqueueOne(a))))(wye.interrupt)
             .onHalt{
               case Kill => Halt(Error(Terminated(Kill)))
               case cause => Halt(cause)

--- a/src/test/scala/scalaz/stream/MergeNSpec.scala
+++ b/src/test/scala/scalaz/stream/MergeNSpec.scala
@@ -168,6 +168,15 @@ object MergeNSpec extends Properties("mergeN") {
     r.size == 2
   }
 
+  // tests that mergeN does not deadlock when the producer is waiting for enqueue to complete
+  // this is really testing `njoin`
+  property("bounded-mergeN-halts-onFull") = secure {
+    merge.mergeN(1)(emit(constant(())))
+	.once
+	.run.timed(3000).run
+	true
+  }
+
   property("kill mergeN") = secure {
     merge.mergeN(Process(Process.repeatEval(Task.now(1)))).kill.run.timed(3000).run
     true // Test terminates.


### PR DESCRIPTION
This resolves issue #297.

The deadlock occurs when the process is 'stuck' waiting for queue.enqueue to complete. Since `to` evaluates actions serially, the only way to allow the process to proceed and react to the completion signal is to interrupt the enqueue action.
The fix here is to make enqueue interruptible.