### PR TITLE
Fixes signalOf deadlock and deprecates signal

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -798,8 +798,8 @@ object Process extends ProcessInstances {
     implicit S: Strategy,
     scheduler: ScheduledExecutorService): Process[Task, Duration] = {
     def metronomeAndSignal:(()=>Unit,async.mutable.Signal[Duration]) = {
-      val signal = async.signal[Duration](S)
       val t0 = Duration(System.nanoTime, NANOSECONDS)
+      val signal = async.toSignal[Duration](Process.halt)(S)
 
       val metronome = scheduler.scheduleAtFixedRate(
         new Runnable { def run = {

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -36,18 +36,16 @@ package object async {
   /**
    * Create a new continuous signal which may be controlled asynchronously.
    */
+  @deprecated("Use signalOf instead", "0.7.0")
   def signal[A](implicit S: Strategy): Signal[A] =
-    Signal(halt, haltOnSource = false)
+    toSignal(halt)
 
   /**
    * Creates a new continuous signalwhich may be controlled asynchronously,
    * and immediately sets the value to `initialValue`.
    */
-  def signalOf[A](initialValue: A)(implicit S: Strategy): Signal[A] = {
-    val s = signal[A]
-    s.set(initialValue).run
-    s
-  }
+  def signalOf[A](initialValue: A)(implicit S: Strategy): Signal[A] =
+    toSignal(Process(initialValue))
 
   /**
    * Converts discrete process to signal. Note that, resulting signal must be manually closed, in case the

--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -36,7 +36,7 @@ package object nondeterminism {
 
     suspend {
       val q = async.boundedQueue[A](maxQueued)(S)
-      val done = async.signal[Boolean](S)
+      val done = async.signalOf(false)(S)
 
       //keep state of master source
       var state: Either3[Cause, EarlyCause => Unit,  Cont[Task,Process[Task,A]]] =
@@ -84,9 +84,9 @@ package object nondeterminism {
         }
       }
 
-      // initially sets signal and starts the source evaluation
+      // starts the source evaluation
       def start: Task[Unit] =
-        done.set(false).map { _ => actor ! Start }
+        Task delay { actor ! Start }
 
       def sourceDone = state.leftOr(false)(_=>true)
 

--- a/src/test/scala/scalaz/stream/MergeNSpec.scala
+++ b/src/test/scala/scalaz/stream/MergeNSpec.scala
@@ -108,6 +108,7 @@ object MergeNSpec extends Properties("mergeN") {
     val count = 100
     val eachSize = 10
 
+    // TODO replace with signalOf; what follows is immensely confusing and tricky...
     val sizeSig = async.signal[Int]
 
     def incrementOpen =

--- a/src/test/scala/scalaz/stream/NioSpec.scala
+++ b/src/test/scala/scalaz/stream/NioSpec.scala
@@ -114,8 +114,7 @@ object NioSpec extends Properties("nio") {
     val array1 = Array.fill[Byte](size)(1)
     Random.nextBytes(array1)
 
-    val stop = async.signal[Boolean]
-    stop.set(false).run
+    val stop = async.signalOf(false)
 
     val serverGot = new SyncVar[Throwable \/ IndexedSeq[Byte]]
     stop.discrete.wye(NioServer.echo(local))(wye.interrupt)
@@ -140,8 +139,7 @@ object NioSpec extends Properties("nio") {
     val array1 = Array.fill[Byte](size)(1)
     Random.nextBytes(array1)
 
-    val stop = async.signal[Boolean]
-    stop.set(false).run
+    val stop = async.signalOf(false)
 
     val serverGot = new SyncVar[Throwable \/ IndexedSeq[Byte]]
     stop.discrete.wye(NioServer.limit(local,max))(wye.interrupt)
@@ -169,8 +167,7 @@ object NioSpec extends Properties("nio") {
     val array1 = Array.fill[Byte](size)(1)
     Random.nextBytes(array1)
 
-    val stop = async.signal[Boolean]
-    stop.set(false).run
+    val stop = async.signalOf(false)
 
 
     val serverGot = new SyncVar[Throwable \/ Seq[Seq[Byte]]]

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -255,8 +255,7 @@ object WyeSpec extends  Properties("Wye"){
   //tests specific case of termination with nested wyes and interrupt
   property("nested-interrupt") = secure {
     val sync = new SyncVar[Throwable \/ IndexedSeq[Unit]]
-    val term1 = async.signal[Boolean]
-    term1.set(false).run
+    val term1 = async.signalOf(false)
 
     val p1: Process[Task,Unit] = (Process.sleep(10.hours) ++ emit(true)).wye(Process.sleep(10 hours))(wye.interrupt)
     val p2:Process[Task,Unit] = repeatEval(Task.now(true)).flatMap(_ => p1)


### PR DESCRIPTION
This fixes #301 and deprecates the highly dubious `async.signal` construction.  If you *absolutely* need an uninitialized signal (as is the case inside `Process.awakeEvery`), use `async.toSignal(Process.halt)`.  Don't use uninitialized signals.