### PR TITLE
Refine the output type of Process.duration to FiniteDuration

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -836,9 +836,9 @@ object Process extends ProcessInstances {
    * Note that the actual granularity of these elapsed times depends on the OS, for instance
    * the OS may only update the current time every ten milliseconds or so.
    */
-  def duration: Process[Task, Duration] =
+  def duration: Process[Task, FiniteDuration] =
     eval(Task.delay(System.nanoTime)).flatMap { t0 =>
-      repeatEval(Task.delay(Duration(System.nanoTime - t0, NANOSECONDS)))
+      repeatEval(Task.delay(FiniteDuration(System.nanoTime - t0, NANOSECONDS)))
     }
 
   /** A `Writer` which emits one value to the output. */


### PR DESCRIPTION
`Process.duration` uses a [`Duration.apply` function](https://github.com/scala/scala/blob/v2.11.5/src/library/scala/concurrent/duration/Duration.scala#L33) that always returns a `FiniteDuration` so that we can change the output type of `duration` to the more precise `FiniteDuration`. Using `Duration` as type here is just an unnecessary loss of information.