### PR TITLE
tee to propagate error cause to its input Processes, as part of Kill

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -126,27 +126,25 @@ sealed trait Process[+F[_], +O]
    * is killed with same reason giving it an opportunity to cleanup.
    */
   final def pipe[O2](p1: Process1[O, O2]): Process[F, O2] =
-    p1.suspendStep.flatMap({ s1 =>
-      s1 match {
-        case s@Step(awt1@Await1(rcv1), cont1) =>
-          val nextP1 = s.toProcess
-          this.step match {
-            case Step(awt@Await(_, _), cont) => awt.extend(p => (p +: cont) pipe nextP1)
-            case Step(Emit(os), cont)        => cont.continue pipe process1.feed(os)(nextP1)
-            case hlt@Halt(End)               => hlt pipe nextP1.disconnect(Kill).swallowKill
-            case hlt@Halt(rsn: EarlyCause)   => hlt pipe nextP1.disconnect(rsn)
-          }
+    p1.suspendStep.flatMap({
+      case s@Step(awt1@Await1(rcv1), cont1) =>
+        val nextP1 = s.toProcess
+        this.step match {
+          case Step(awt@Await(_, _), cont) => awt.extend(p => (p +: cont) pipe nextP1)
+          case Step(Emit(os), cont)        => cont.continue pipe process1.feed(os)(nextP1)
+          case hlt@Halt(End)               => hlt pipe nextP1.disconnect(Kill).swallowKill
+          case hlt@Halt(rsn: EarlyCause)   => hlt pipe nextP1.disconnect(rsn)
+        }
 
-        case Step(emt@Emit(os), cont)      =>
-          // When the pipe is killed from the outside it is killed at the beginning or after emit.
-          // This ensures that Kill from the outside is not swallowed.
-          emt onHalt {
-            case End => this.pipe(cont.continue)
-            case early => this.pipe(Halt(early) +: cont).causedBy(early)
-          }
+      case Step(emt@Emit(os), cont) =>
+        // When the pipe is killed from the outside it is killed at the beginning or after emit.
+        // This ensures that Kill from the outside is not swallowed.
+        emt onHalt {
+          case End   => this.pipe(cont.continue)
+          case early => this.pipe(Halt(early) +: cont).causedBy(early)
+        }
 
-        case Halt(rsn)           => this.kill onHalt { _ => Halt(rsn) }
-      }
+      case Halt(rsn) => this.kill onHalt { _ => Halt(rsn)}
     })
 
   /** Operator alias for `pipe`. */
@@ -168,37 +166,35 @@ sealed trait Process[+F[_], +O]
    */
   final def tee[F2[x] >: F[x], O2, O3](p2: Process[F2, O2])(t: Tee[O, O2, O3]): Process[F2, O3] = {
     import scalaz.stream.tee.{AwaitL, AwaitR, disconnectL, disconnectR, feedL, feedR}
-    t.suspendStep flatMap { ts =>
-      ts match {
-        case s@Step(AwaitL(_), contT) => this.step match {
-          case Step(awt@Await(rq, rcv), contL) => awt.extend { p => (p  +: contL).tee(p2)(s.toProcess) }
-          case Step(Emit(os), contL)           => contL.continue.tee(p2)(feedL[O, O2, O3](os)(s.toProcess))
-          case hlt@Halt(End)              => hlt.tee(p2)(disconnectL(Kill)(s.toProcess).swallowKill)
-          case hlt@Halt(rsn: EarlyCause)  => hlt.tee(p2)(disconnectL(rsn)(s.toProcess))
-        }
-
-        case s@Step(AwaitR(_), contT) => p2.step match {
-          case s2: Step[F2, O2]@unchecked =>
-            (s2.head, s2.next) match {
-              case (awt: Await[F2, Any, O2]@unchecked, contR) =>
-                awt.extend { (p: Process[F2, O2]) => this.tee(p +: contR)(s.toProcess) }
-              case (Emit(o2s), contR) =>
-                this.tee(contR.continue.asInstanceOf[Process[F2,O2]])(feedR[O, O2, O3](o2s)(s.toProcess))
-            }
-          case hlt@Halt(End)              => this.tee(hlt)(disconnectR(Kill)(s.toProcess).swallowKill)
-          case hlt@Halt(rsn : EarlyCause) => this.tee(hlt)(disconnectR(rsn)(s.toProcess))
-        }
-
-        case Step(emt@Emit(o3s), contT) =>
-          // When the process is killed from the outside it is killed at the beginning or after emit.
-          // This ensures that Kill from the outside isn't swallowed.
-          emt onHalt {
-            case End => this.tee(p2)(contT.continue)
-            case early => this.tee(p2)(Halt(early) +: contT).causedBy(early)
-          }
-
-        case Halt(rsn)             => this.kill(rsn) onHalt { _ => p2.kill(rsn) onHalt { _ => Halt(rsn) } }
+    t.suspendStep flatMap {
+      case s@Step(AwaitL(_), contT) => this.step match {
+        case Step(awt@Await(rq, rcv), contL) => awt.extend { p => (p +: contL).tee(p2)(s.toProcess)}
+        case Step(Emit(os), contL)           => contL.continue.tee(p2)(feedL[O, O2, O3](os)(s.toProcess))
+        case hlt@Halt(End)                   => hlt.tee(p2)(disconnectL(Kill)(s.toProcess).swallowKill)
+        case hlt@Halt(rsn: EarlyCause)       => hlt.tee(p2)(disconnectL(rsn)(s.toProcess))
       }
+
+      case s@Step(AwaitR(_), contT) => p2.step match {
+        case s2: Step[F2, O2]@unchecked =>
+          (s2.head, s2.next) match {
+            case (awt: Await[F2, Any, O2]@unchecked, contR) =>
+              awt.extend { (p: Process[F2, O2]) => this.tee(p +: contR)(s.toProcess)}
+            case (Emit(o2s), contR)                         =>
+              this.tee(contR.continue.asInstanceOf[Process[F2, O2]])(feedR[O, O2, O3](o2s)(s.toProcess))
+          }
+        case hlt@Halt(End)              => this.tee(hlt)(disconnectR(Kill)(s.toProcess).swallowKill)
+        case hlt@Halt(rsn: EarlyCause)  => this.tee(hlt)(disconnectR(rsn)(s.toProcess))
+      }
+
+      case Step(emt@Emit(o3s), contT) =>
+        // When the process is killed from the outside it is killed at the beginning or after emit.
+        // This ensures that Kill from the outside isn't swallowed.
+        emt onHalt {
+          case End   => this.tee(p2)(contT.continue)
+          case early => this.tee(p2)(Halt(early) +: contT).causedBy(early)
+        }
+
+      case Halt(rsn) => this.kill(rsn) onHalt { _ => p2.kill(rsn) onHalt { _ => Halt(rsn)}}
     }
   }
 

--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -119,8 +119,8 @@ package object nondeterminism {
             //killed behaviour of upstream termination
             done.discrete.wye(p.flatMap(a => eval_(q.enqueueOne(a))))(wye.interrupt)
             .onHalt{
-              case Kill => Halt(Error(Terminated(Kill)))
-              case cause => Halt(cause)
+              case k: Kill => Halt(Error(Terminated(k)))
+              case cause   => Halt(cause)
             }
             .run.runAsync { res =>
               S(actor ! Finished(res))
@@ -142,7 +142,7 @@ package object nondeterminism {
           // kill all the open processes including the `source`
           case Finished(-\/(rsn)) =>
             val cause = rsn match {
-              case Terminated(Kill) => Kill
+              case Terminated(k: Kill) => k
               case _ => Error(rsn)
             }
             opened = opened - 1

--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -68,11 +68,11 @@ object ResourceSafetySpec extends Properties("resource-safety") {
       // Left side terminates normally, right side terminates with kill.
       , ("tee-cln-down", (src onHalt cleanup).zip(src onHalt cleanup) onHalt cleanup, right(()), List(End, Kill, End))
       , ("tee-cln-tee", (src onHalt cleanup).tee(src onHalt cleanup)(fail(bwah)) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Kill(Error(bwah).some), Error(bwah)))
-      , ("wye-cln-left", (src onHalt cleanup).wye(fail(bwah))(wye.yip) onHalt cleanup, left(bwah), List(Kill, Error(bwah)))
-      , ("wye-cln-right", fail(bwah).wye(src onHalt cleanup)(wye.yip) onHalt cleanup, left(bwah), List(Kill, Error(bwah)))
+      , ("wye-cln-left", (src onHalt cleanup).wye(fail(bwah))(wye.yip) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Error(bwah)))
+      , ("wye-cln-right", fail(bwah).wye(src onHalt cleanup)(wye.yip) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Error(bwah)))
       // `cleanup` on both sides is called at the same moment.
       , ("wye-cln-down", (src onHalt cleanup).wye(src onHalt cleanup)(wye.yip) onHalt cleanup, right(()), List(End, End, End))
-      , ("wye-cln-wye", (src onHalt cleanup).wye(src onHalt cleanup)(fail(bwah)) onHalt cleanup, left(bwah), List(Kill, Kill, Error(bwah)))
+      , ("wye-cln-wye", (src onHalt cleanup).wye(src onHalt cleanup)(fail(bwah)) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Kill(Error(bwah).some), Error(bwah)))
     )
 
     val result = procs.zipWithIndex.map {

--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -47,7 +47,7 @@ object ResourceSafetySpec extends Properties("resource-safety") {
      , ("append-lzy", (src ++ die) onHalt cleanup,  left(bwah), List(Error(bwah)))
      , ("pipe-term-p1", src.pipe(fail(bwah)) onHalt cleanup,  left(bwah), List(Error(bwah)))
      , ("pipe-term-src", fail(bwah).pipe(process1.id) onHalt cleanup,  left(bwah), List(Error(bwah)))
-     , ("pipe-cln-src", (src onHalt cleanup).pipe(fail(bwah)) onHalt cleanup ,  left(bwah), List(Kill, Error(bwah)))
+     , ("pipe-cln-src", (src onHalt cleanup).pipe(fail(bwah)) onHalt cleanup ,  left(bwah), List(Kill(Error(bwah).some), Error(bwah)))
      , ("pipe-cln-p1", src.pipe(fail(bwah) onHalt cleanup) onHalt cleanup ,  left(bwah), List(Error(bwah),Error(bwah)))
      , ("pipe-fail-src-then-p1", (src ++ fail(bwah)).pipe(process1.id[Int] onComplete fail(boom) onHalt cleanup), left(CausedBy(boom, bwah)), List(Error(CausedBy(boom, bwah))))
      , ("pipe-fail-p1-then-src", ((src onComplete fail(bwah)) onHalt cleanup).pipe(fail(boom)), left(boom), List(Error(bwah)))

--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.LinkedBlockingDeque
 import Process._
 import scalaz.-\/
 import scalaz.\/._
+import scalaz.syntax.std.option._
 
 
 object ResourceSafetySpec extends Properties("resource-safety") {
@@ -62,11 +63,11 @@ object ResourceSafetySpec extends Properties("resource-safety") {
 //      , src.fby(die) onComplete cleanup
 //      , src.orElse(die) onComplete cleanup
 //      , (src append die).orElse(halt,die) onComplete cleanup
-      , ("tee-cln-left", (src onHalt cleanup).zip(fail(bwah)) onHalt cleanup, left(bwah), List(Kill, Error(bwah)))
-      , ("tee-cln-right", fail(bwah).zip(src onHalt cleanup) onHalt cleanup, left(bwah), List(Kill, Error(bwah)))
+      , ("tee-cln-left", (src onHalt cleanup).zip(fail(bwah)) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Error(bwah)))
+      , ("tee-cln-right", fail(bwah).zip(src onHalt cleanup) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Error(bwah)))
       // Left side terminates normally, right side terminates with kill.
       , ("tee-cln-down", (src onHalt cleanup).zip(src onHalt cleanup) onHalt cleanup, right(()), List(End, Kill, End))
-      , ("tee-cln-tee", (src onHalt cleanup).tee(src onHalt cleanup)(fail(bwah)) onHalt cleanup, left(bwah), List(Kill, Kill, Error(bwah)))
+      , ("tee-cln-tee", (src onHalt cleanup).tee(src onHalt cleanup)(fail(bwah)) onHalt cleanup, left(bwah), List(Kill(Error(bwah).some), Kill(Error(bwah).some), Error(bwah)))
       , ("wye-cln-left", (src onHalt cleanup).wye(fail(bwah))(wye.yip) onHalt cleanup, left(bwah), List(Kill, Error(bwah)))
       , ("wye-cln-right", fail(bwah).wye(src onHalt cleanup)(wye.yip) onHalt cleanup, left(bwah), List(Kill, Error(bwah)))
       // `cleanup` on both sides is called at the same moment.


### PR DESCRIPTION
The basic idea is to replace `case object Kill` with `case class Kill(upstreamCause: Option[Error])`, together with a handy constructor that can create a `Kill` out of any `Cause`.

Then, upon encountering a `Halt(rsn)` in the evaluation of the `Tee`, `Process.tee` would `.kill(rsn)` its input processes (this is a new method), which will record `rsn`, if it's an `Error`, as part of the `Kill` instance.

The 3rd commit introduces `Process.onSuccess`, a finalizer that runs only if the process halted "successfully" i.e. with an `End` or a `Kill(None)` -- one that was not caused by an error. It then uses this to rewrite `io.bufferedChannel` such that it performs its `flush` Task only on success.

Please see my comment here for the full description: https://github.com/scalaz/scalaz-stream/issues/288#issuecomment-73311627