### PR TITLE
Implemented (and documented) a safe(r) toTask-like function

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -7,7 +7,6 @@ import scalaz.{Catchable, Functor, Monad, Monoid, Nondeterminism, \/, -\/, ~>}
 import scalaz.\/._
 import scalaz.concurrent.{Actor, Strategy, Task}
 import scalaz.stream.process1.Await1
-import scalaz.syntax.monad._
 
 /**
  * An effectful stream of `O` values. In between emitting values


### PR DESCRIPTION
`Process.toTask` isn't referentially transparent (see #315).  This deprecates `toTask` and introduces `stepTask`, which satisfies the same use-case while being easier to reason about.  Note that `stepTask` still shares the major foible of `toTask`, which is that premature abortion of the step process will result in resource leaks, but at least the type signature now provides sufficient power to reason about restart semantics.  If nothing else, maybe the documentation will help a bit.