### PR TITLE
Adds pipe + merge test in WyeSpec. Test nondeterministically fails.

### DIFF
--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -399,4 +399,12 @@ object WyeSpec extends  Properties("Wye"){
     val v = i1.wye(p2)(wye.interrupt).runLog.timed(3000).run.toList
     v.size >= 0
   }
+
+  property("interrupt-pipe with wye.merge") = secure {
+    val p1 = Process.constant(42).collect { case i if i < 0 => i } merge Process.constant(12)
+    val p2 = p1 |> process1.id
+    val i1 = Process(false)
+    val v = i1.wye(p2)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
 }


### PR DESCRIPTION
I added this test, and sometimes it fails (i.e. times out). When I commented out all but the last two tests in the suite in failed consistently. When I ran `sbt test-only *WyeSpec*` the added test failed once and passed once.