### PR TITLE
Wye clobbered halt fix

### DIFF
--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -251,6 +251,20 @@ object WyeSpec extends  Properties("Wye"){
 
     (pm1 ++ pm2).runLog.timed(3000).run.size == 4
   }
+  
+  property("mergeHaltBoth.terminate-on-doubleHalt") = secure {
+    implicit val scheduler = DefaultScheduler
+
+    for (i <- 1 to 100) {
+      val q = async.unboundedQueue[Unit]
+      q.enqueueOne(()).run
+
+      val process = ((q.dequeue merge halt).once wye halt)(wye.mergeHaltBoth)
+      process.run.timed(3000).run
+    }
+
+    true
+  }
 
   //tests specific case of termination with nested wyes and interrupt
   property("nested-interrupt") = secure {


### PR DESCRIPTION
Fixes #316.

In addition to ensuring multiple terminate requests complete, this will also complete the pending `Get`, if there is one, before attempting to kill.