### PR TITLE
Cleaner runAsync without redundant cleanups

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1239,8 +1239,9 @@ object Process extends ProcessInstances {
 
                 case \/-(p) => {
                   // pointer equality test for convenience; not actually needed
-                  if (ref.compareAndSet(liftedInterrupt, null)) {      // can't swap in runAsync right await, because side effects!
-                    ref.set(p.runAsync(cb))      // we made it! swap out interrupt
+                  if (ref.compareAndSet(liftedInterrupt, null)) {
+                    // we need to fail-trampoline to avoid infinite recursion on drained processes
+                    cb(\/-((Nil, Cont(Vector({ _ => Trampoline done p })))))
                   } else {
                     ()      // interrupt happened after we completed but before we checked; no-op
                   }

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1198,13 +1198,13 @@ object Process extends ProcessInstances {
      * @return   Function to interrupt the evaluation
      */
     protected[stream] final def runAsync(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit)(implicit S: Strategy): EarlyCause => Unit = {
-      def go(p: Process[Task, O]): Task[EarlyCause => Unit] = Task delay {
+      def go(p: Process[Task, O])(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit): Task[EarlyCause => Unit] = Task delay {
         p.step match {
           case Halt(cause) =>
-            (Task delay cb(-\/(cause))) >> (Task now { _: EarlyCause => () })
+            (Task delay { S { cb(-\/(cause)) } }) >> (Task now { _: EarlyCause => () })
 
           case Step(Emit(os), cont) =>
-            (Task delay { cb(\/-((os, cont))) }) >> (Task now { _: EarlyCause => () })
+            (Task delay { S { cb(\/-((os, cont))) } }) >> (Task now { _: EarlyCause => () })
 
           case Step(Await(req, rcv), cont) => {
             val await: Task[Process[Task, O]] = req.attempt map { either =>
@@ -1212,23 +1212,44 @@ object Process extends ProcessInstances {
             }
 
             Task delay {
+              val interrupted = new AtomicReference[Option[EarlyCause]](None)      // this is necessary to catch interrupts that are late in halting very fast tasks
               val ref = new AtomicReference[EarlyCause => Unit]
 
               lazy val interrupt: () => Unit = await runAsyncInterruptibly {
+                // explicitly catch interrupts
+                case -\/(Task.TaskInterrupted) => ()      // we were interrupted; someone else will kill things off (this is part 1 of the double-cleanup case)
+
                 case -\/(t) => {
                   if (ref.compareAndSet(liftedInterrupt, null)) {
-                    go(cont.continue.injectCause(Error(t)).drain.causedBy(Error(t)))
+                    ref.compareAndSet(null, go(Try(rcv(-\/(Error(t))).run) +: cont)(cb).run)      // analogous to the success case
                   } else {
-                    ()      // we got an exception (possibly an interrupt); cause already propagated
+                    ()      // we got an exception (apparently an interrupt?); cause already propagated
                   }
                 }
 
                 case \/-(p) => {
                   // pointer equality test for convenience; not actually needed
                   if (ref.compareAndSet(liftedInterrupt, null)) {
-                    // we need to fail-trampoline to avoid infinite recursion on drained processes
-                    cb(\/-((Nil, Cont(Vector({ _ => Trampoline done p })))))
+                    val recurse = go(p) {
+                      case -\/(cause) => cb(-\/(cause))
+
+                      // we completed the task, then got interrupted before we invoked the callback; discard results and drain!
+                      case \/-((_, cont)) if interrupted.get().isDefined => {
+                        val cause = interrupted.get().get
+
+                        cont.continue.injectCause(cause).drain.run runAsync {
+                          case -\/(t) => S { cb(-\/(Error(t) causedBy cause)) }
+                          case \/-(_) => S { cb(-\/(cause)) }
+                        }
+                      }
+
+                      case \/-(pair) => cb(\/-(pair))
+                    }
+
+                    ref.compareAndSet(null, recurse.run)
                   } else {
+                    // TODO this is part 2 of the case where the double-cleanup happens in master
+
                     ()      // interrupt happened after we completed but before we checked; no-op
                   }
                 }
@@ -1238,7 +1259,11 @@ object Process extends ProcessInstances {
                 if (ref.compareAndSet(liftedInterrupt, null)) {
                   interrupt()
 
-                  go(cont.continue.injectCause(cause).drain.causedBy(cause))
+                  // successfully interrupted, now drain the rest of the process
+                  (Try(rcv(-\/(cause)).run) +: cont).run runAsync {
+                    case -\/(t) => S { cb(-\/(Error(t) causedBy cause)) }
+                    case \/-(_) => S { cb(-\/(cause)) }
+                  }
                 } else {
                   referencedInterrupt(cause)      // completed naturally just as we were interrupted; forward along
                 }
@@ -1247,8 +1272,11 @@ object Process extends ProcessInstances {
               ref.set(liftedInterrupt)
               interrupt        // force the lazy val
 
-              def referencedInterrupt(cause: EarlyCause): Unit =
+              // note there is a real chance of a NPE coming out of here under interrupt contention, and I'm ok with that because the types are stupid!
+              def referencedInterrupt(cause: EarlyCause): Unit = {
+                interrupted.set(Some(cause))
                 ref.get()(cause)
+              }
 
               referencedInterrupt _
             }
@@ -1256,7 +1284,7 @@ object Process extends ProcessInstances {
         }
       } join
 
-      go(self).run   // hey, we could totally return something sane here! what up?
+      go(self)(cb).run   // hey, we could totally return something sane here! what up?
     }
   }
 

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1198,7 +1198,7 @@ object Process extends ProcessInstances {
      * @return   Function to interrupt the evaluation
      */
     protected[stream] final def runAsync(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit)(implicit S: Strategy): EarlyCause => Unit = {
-      lazy val asyncStep: Task[EarlyCause => Unit] = Task delay {
+      val asyncStep: Task[EarlyCause => Unit] = Task delay {
         self.step match {
           case Halt(cause) =>
             (Task delay cb(-\/(cause))) >> (Task now { _: EarlyCause => () })

--- a/src/main/scala/scalaz/stream/tcp.scala
+++ b/src/main/scala/scalaz/stream/tcp.scala
@@ -289,8 +289,11 @@ object tcp {
     def connect(ch: AsynchronousSocketChannel): Task[AsynchronousSocketChannel] =
       Task.async[AsynchronousSocketChannel] { cb =>
         ch.connect(to, null, new CompletionHandler[Void, Void] {
-          def completed(result: Void, attachment: Void): Unit = cb(right(ch))
-          def failed(rsn: Throwable, attachment: Void): Unit = cb(left(rsn))
+          def completed(result: Void, attachment: Void): Unit =
+            cb(right(ch))
+
+          def failed(rsn: Throwable, attachment: Void): Unit =
+            cb(left(rsn))
         })
       }
 
@@ -335,6 +338,7 @@ object tcp {
         sch.accept(null, new CompletionHandler[AsynchronousSocketChannel, Void] {
           def completed(result: AsynchronousSocketChannel, attachment: Void): Unit =
             S { cb(right(result)) }
+
           def failed(rsn: Throwable, attachment: Void): Unit =
             S { cb(left(rsn)) }
         })

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -317,7 +317,7 @@ object ProcessSpec extends Properties("Process") {
     Thread.sleep(200)     // ensure the task actually completes
 
     (result.get(3000).get == -\/(Kill)) :| "computation result" &&
-      (inner.get() == 0) :| "inner finalizer invocation count" &&
+      (inner.get() == 1) :| "inner finalizer invocation count" &&
       (outer.get() == 1) :| "outer finalizer invocation count"
   }
 

--- a/src/test/scala/scalaz/stream/TcpSpec.scala
+++ b/src/test/scala/scalaz/stream/TcpSpec.scala
@@ -14,6 +14,7 @@ import scalaz.\/-
 import scalaz.concurrent.{Strategy,Task}
 import scalaz.stream.Process.Halt
 import scalaz.stream.ReceiveY._
+import scalaz.syntax.monad._
 import scodec.bits.ByteVector
 
 object TcpSpec extends Properties("tcp") {
@@ -94,20 +95,20 @@ object TcpSpec extends Properties("tcp") {
     val E = java.util.concurrent.Executors.newCachedThreadPool
     val S2 = Strategy.Executor(E)
 
-    lazy val server = Process.suspend {
+    lazy val server = {
       val topic = async.topic[String]()
       val chat =
         tcp.reads(1024).pipe(text.utf8Decode).to(topic.publish).wye {
           tcp.writes(tcp.lift(topic.subscribe.pipe(text.utf8Encode)))
         } (wye.mergeHaltBoth)
-      tcp.server(addr, concurrentRequests = 50)(chat).runLog.run.head
+      tcp.server(addr, concurrentRequests = 1)(chat) join     // TODO this should eventually go back to "not 1". frankly, I don't know how this is working at all even now
     }
     lazy val link = async.signalOf(false)
     lazy val startServer =
       link.discrete.wye(server)(wye.interrupt)
           .run
           .runAsync { _.fold(e => throw e, identity) }
-    lazy val stopServer = { E.shutdown(); link.set(true).run }
+    lazy val stopServer = { println("shutting down"); E.shutdown(); link.set(true).run }
 
     property("setup") = forAll ((i: Int) => { startServer; true })
     property("go") =

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -244,7 +244,7 @@ object WyeSpec extends  Properties("Wye"){
   //tests that wye correctly terminates drained process
   property("merge-drain-halt") = secure {
 
-    val effect:Process[Task,Int] = Process.repeatEval(Task.delay(())).drain
+    val effect:Process[Task,Int] = Process.repeatEval(Task delay { () }).drain
 
     val pm1 = effect.wye(Process(1000,2000).toSource)(wye.merge).take(2)
     val pm2 = Process(3000,4000).toSource.wye(effect)(wye.merge).take(2)


### PR DESCRIPTION
There's really no reason (that I can think of) for `runAsync` to be implemented using raw `Actor`.  This reimplements it using `Task`, also fixing a bug regarding duplicated `onComplete` evaluation, cleaning up the signaling, making the interrupt mechanism more responsive, and also opens the door to a more reasonable type signature down the road (propagating the `Task` context into `njoin` and `wye`).

The first of the two really notable changes here are that we are now using `Task`'s `runAsyncInterruptibly`, which gives us the ability to kill a `Task` (within limits).  This is a strict improvement over the old `Process#runAsync`, which would literally leak threads whenever a `Task` continued running for a long time after the interrupt.  This happens, for example, if we do a `Process.await(p.run) { ... }`, where `p` is some long-running process, running `Process#runAsync` on that result would leak a LOT of computational resources.  No more!

The second change is that we are no longer invoking finalizers multiple times.  This is a really subtle issue, but you can see it here:

```scala
              case Interrupt(cause) if completed.isEmpty =>
                completed = Some(cause)
                Try(cleanup(cause)).run.runAsync(_.fold(
                  rsn0 =>  cb(left(Error(rsn0).causedBy(cause)))
                  , _ => cb(left(cause))
                ))
```

…and here!

```scala
              case AwaitDone(r, awt, _) =>
                Try(awt.rcv(EarlyCause(r)).run)
                .kill
                .run.runAsync(_ => ())
```

Combined with this:

```scala
              case Step(awt@Await(req, rcv), cont) =>
                req.runAsync(r => a ! AwaitDone(r, awt, cont))
                right((c:EarlyCause) => rcv(left(c)).run +: cont)
```

So with the *old* `runAsync`, when we interrupt a process, we immediately run its cleanup, but we don't terminate the task!  Thus, the task will eventually complete… and then run the whole process again.  Hurray!

This PR fixes several of the issues that we (@alissapajer and I) have seen in concurrent code, including several out the outstanding "`wye` issues".