### PR TITLE
Adds oraclejdk8 to travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ scala:
   - 2.11.4
 jdk:
   - oraclejdk7
+  - oraclejdk8
   - openjdk7
 # sudo: false
 cache:


### PR DESCRIPTION
Under the [Testing Against Multiple JDKs](http://docs.travis-ci.com/user/languages/java/#Testing-Against-Multiple-JDKs) section, one can see that `openjdk8` is not supported. Hence why the PR just includes `oraclejdk8`. 