### PR TITLE
Cherry-picks `step` fixes from Pavel's PR

### DIFF
--- a/src/main/scala/scalaz/stream/Cause.scala
+++ b/src/main/scala/scalaz/stream/Cause.scala
@@ -65,7 +65,7 @@ object Cause {
   sealed trait EarlyCause extends Cause
 
   object EarlyCause {
-    def apply[A](r:Throwable\/A):EarlyCause\/A =
+    def fromTaskResult[A](r:Throwable\/A):EarlyCause\/A =
       r.bimap(Error.apply,identity)
   }
 

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1239,8 +1239,9 @@ object Process extends ProcessInstances {
 
                 case \/-(p) => {
                   // pointer equality test for convenience; not actually needed
-                  if (ref.compareAndSet(liftedInterrupt, null)) {      // can't swap in runAsync right await, because side effects!
-                    ref.set(p.runAsync(cb))      // we made it! swap out interrupt
+                  if (ref.compareAndSet(liftedInterrupt, null)) {
+                    // we need to fail-trampoline to avoid infinite recursion on drained processes
+                    cb(\/-((Nil, Cont(Vector({ _ => Trampoline done p })))))
                   } else {
                     ()      // interrupt happened after we completed but before we checked; no-op
                   }

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1307,7 +1307,7 @@ object Process extends ProcessInstances {
                  * extractor.  Under all other circumstances, including interrupts, exceptions and natural completion, the
                  * callback will be invoked exactly once.
                  */
-                val interrupt = completeInterruptibly((Task fork (checkInterrupt >> req)).get) {
+                val interrupt = completeInterruptibly((checkInterrupt >> req).get) {
                   case Interrupted.PreOrMidStep(cause) => {
                     // interrupted; now drain
                     (Try(rcv(-\/(cause)).run) +: cont).drain.run runAsync {
@@ -1356,6 +1356,8 @@ object Process extends ProcessInstances {
      * that value will be passed to the callback as a second return.  Thus, the callback will always be
      * invoked at least once, and may be invoked twice.  If it is invoked twice, the first callback
      * will always be None while the second will be Some.
+     *
+     *
      */
     private def completeInterruptibly[A](f: Future[A])(cb: Option[A] => Unit)(implicit S: Strategy): () => Unit = {
       import Future._
@@ -1403,7 +1405,7 @@ object Process extends ProcessInstances {
         }
       })
 
-      actor ! Some(f)
+      S { actor ! Some(f) }
 
       { () => actor ! None }
     }

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1198,13 +1198,13 @@ object Process extends ProcessInstances {
      * @return   Function to interrupt the evaluation
      */
     protected[stream] final def runAsync(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit)(implicit S: Strategy): EarlyCause => Unit = {
-      def go(p: Process[Task, O]): Task[EarlyCause => Unit] = Task delay {
+      def go(p: Process[Task, O])(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit): Task[EarlyCause => Unit] = Task delay {
         p.step match {
           case Halt(cause) =>
-            (Task delay cb(-\/(cause))) >> (Task now { _: EarlyCause => () })
+            (Task delay { S { cb(-\/(cause)) } }) >> (Task now { _: EarlyCause => () })
 
           case Step(Emit(os), cont) =>
-            (Task delay { cb(\/-((os, cont))) }) >> (Task now { _: EarlyCause => () })
+            (Task delay { S { cb(\/-((os, cont))) } }) >> (Task now { _: EarlyCause => () })
 
           case Step(Await(req, rcv), cont) => {
             val await: Task[Process[Task, O]] = req.attempt map { either =>
@@ -1212,23 +1212,44 @@ object Process extends ProcessInstances {
             }
 
             Task delay {
+              val interrupted = new AtomicReference[Option[EarlyCause]](None)      // this is necessary to catch interrupts that are late in halting very fast tasks
               val ref = new AtomicReference[EarlyCause => Unit]
 
               lazy val interrupt: () => Unit = await runAsyncInterruptibly {
+                // explicitly catch interrupts
+                case -\/(Task.TaskInterrupted) => ()      // we were interrupted; someone else will kill things off (this is part 1 of the double-cleanup case)
+
                 case -\/(t) => {
                   if (ref.compareAndSet(liftedInterrupt, null)) {
-                    go(cont.continue.injectCause(Error(t)).drain.causedBy(Error(t)))
+                    ref.compareAndSet(null, go(Try(rcv(-\/(Error(t))).run) +: cont)(cb).run)      // analogous to the success case
                   } else {
-                    ()      // we got an exception (possibly an interrupt); cause already propagated
+                    ()      // we got an exception (apparently an interrupt?); cause already propagated
                   }
                 }
 
                 case \/-(p) => {
                   // pointer equality test for convenience; not actually needed
                   if (ref.compareAndSet(liftedInterrupt, null)) {
-                    // we need to fail-trampoline to avoid infinite recursion on drained processes
-                    cb(\/-((Nil, Cont(Vector({ _ => Trampoline done p })))))
+                    val recurse = go(p) {
+                      case -\/(cause) => cb(-\/(cause))
+
+                      // we completed the task, then got interrupted before we invoked the callback; discard results and drain!
+                      case \/-((_, cont)) if interrupted.get().isDefined => {
+                        val cause = interrupted.get().get
+
+                        cont.continue.injectCause(cause).drain.run runAsync {
+                          case -\/(t) => S { cb(-\/(Error(t) causedBy cause)) }
+                          case \/-(_) => S { cb(-\/(cause)) }
+                        }
+                      }
+
+                      case \/-(pair) => cb(\/-(pair))
+                    }
+
+                    ref.compareAndSet(null, recurse.run)
                   } else {
+                    // TODO this is part 2 of the case where the double-cleanup happens in master
+
                     ()      // interrupt happened after we completed but before we checked; no-op
                   }
                 }
@@ -1238,7 +1259,11 @@ object Process extends ProcessInstances {
                 if (ref.compareAndSet(liftedInterrupt, null)) {
                   interrupt()
 
-                  go(cont.continue.injectCause(cause).drain.causedBy(cause))
+                  // successfully interrupted, now drain the rest of the process
+                  (Try(rcv(-\/(cause)).run) +: cont).run runAsync {
+                    case -\/(t) => S { cb(-\/(Error(t) causedBy cause)) }
+                    case \/-(_) => S { cb(-\/(cause)) }
+                  }
                 } else {
                   referencedInterrupt(cause)      // completed naturally just as we were interrupted; forward along
                 }
@@ -1247,8 +1272,11 @@ object Process extends ProcessInstances {
               ref.set(liftedInterrupt)
               interrupt        // force the lazy val
 
-              def referencedInterrupt(cause: EarlyCause): Unit =
+              // note there is a real chance of a NPE coming out of here under interrupt contention, and I'm ok with that because the types are stupid!
+              def referencedInterrupt(cause: EarlyCause): Unit = {
+                interrupted.set(Some(cause))
                 ref.get()(cause)
+              }
 
               referencedInterrupt _
             }
@@ -1256,7 +1284,7 @@ object Process extends ProcessInstances {
         }
       } join
 
-      go(self).run   // hey, we could totally return something sane here! what up?
+      go(self)(cb).run   // hey, we could totally return something sane here! what up?
     }
   }
 

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1187,7 +1187,7 @@ object Process extends ProcessInstances {
       async.toSignal(self).continuous
 
     /**
-     * Asynchronous execution of this Process. Note that this method is not resource safe unless
+     * Asynchronous stepping of this Process. Note that this method is not resource safe unless
      * callback is called with _left_ side completed. In that case it is guaranteed that all cleanups
      * has been successfully completed.
      * User of this method is responsible for any cleanup actions to be performed by running the
@@ -1201,13 +1201,15 @@ object Process extends ProcessInstances {
      * There is chance, that cleanup code of intermediate `Await` will get called twice on interrupt, but
      * always at least once. The second cleanup invocation in that case may run on different thread, asynchronously.
      *
+     * Please note that this method is *not* intended for external use!  It is the `Await` analogue of `step`, which
+     * is also an internal-use function.
      *
      * @param cb  result of the asynchronous evaluation of the process. Note that, the callback is never called
      *            on the right side, if the sequence is empty.
      * @param S  Strategy to use when evaluating the process. Note that `Strategy.Sequential` may cause SOE.
      * @return   Function to interrupt the evaluation
      */
-    protected[stream] final def runAsync(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit)(implicit S: Strategy): EarlyCause => Unit = {
+    protected[stream] final def stepAsync(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit)(implicit S: Strategy): EarlyCause => Unit = {
       val allSteps = Task delay {
         /*
          * Represents the running state of the computation.  If we're running, then the interrupt

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1362,11 +1362,11 @@ object Process extends ProcessInstances {
 
                   exceptional = { t =>
                     // we got an exception (not an interrupt!) and we need to drain everything
-                    go(Try(rcv(-\/(Error(t))).run) +: cont).run
+                    go(Try(rcv(-\/(Error(t))).run) +: cont) runAsync { _ => () }
                   },
 
                   completed = { continuation =>
-                    go(continuation).run      // we completed successfully; forward along the reference
+                    go(continuation) runAsync { _ => () }
                   }
                 ))
 

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1198,7 +1198,7 @@ object Process extends ProcessInstances {
      * @return   Function to interrupt the evaluation
      */
     protected[stream] final def runAsync(cb: Cause \/ (Seq[O], Cont[Task,O]) => Unit)(implicit S: Strategy): EarlyCause => Unit = {
-      lazy val asyncStep: Task[EarlyCause => Unit] = Task delay {
+      val asyncStep: Task[EarlyCause => Unit] = Task delay {
         self.step match {
           case Halt(cause) =>
             (Task delay cb(-\/(cause))) >> (Task now { _: EarlyCause => () })

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -77,21 +77,21 @@ sealed trait Process[+F[_], +O]
     @tailrec
     def go(cur: Process[F,O], stack: Vector[Cause => Trampoline[Process[F,O]]], cnt: Int) : HaltOrStep[F,O] = {
       if (stack.nonEmpty) cur match {
-        case Halt(End) if cnt <=0  => Step(empty,Cont(stack))
-        case Halt(cause) => go(Try(stack.head(cause).run), stack.tail, cnt -1)
+        case Halt(End) if cnt <= 0  => Step(empty,Cont(stack))
+        case Halt(cause) => go(Try(stack.head(cause).run), stack.tail, cnt - 1)
         case Emit(os) if os.isEmpty => Step(empty,Cont(stack))
         case emt@(Emit(os)) => Step(emt,Cont(stack))
         case awt@Await(_,_) => Step(awt,Cont(stack))
-        case Append(h,st) => go(h, st fast_++ stack, cnt -1)
+        case Append(h,st) => go(h, st fast_++ stack, cnt - 1)
       } else cur match {
         case hlt@Halt(cause) => hlt
-        case emt@Emit(os) if (os.isEmpty) => halt0
+        case emt@Emit(os) if os.isEmpty => halt0
         case emt@Emit(os) => Step(emt,Cont(Vector.empty))
         case awt@Await(_,_) => Step(awt,Cont(Vector.empty))
-        case Append(h,st) => go(h,st, cnt -1)
+        case Append(h,st) => go(h,st, cnt - 1)
       }
     }
-    go(this,Vector.empty, 10)
+    go(this,Vector.empty, 10)   // *any* value >= 1 works here. higher values improve throughput but reduce concurrency and fairness. 10 is a totally wild guess
 
   }
 

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1384,7 +1384,7 @@ object Process extends ProcessInstances {
                       }
                     }
 
-                    case \/-(_) => ()    // ?????
+                    case \/-(_) => ()    // interrupted a second (or more) time; discard later causes and keep the first one
                   }
                 }
 

--- a/src/main/scala/scalaz/stream/async/mutable/WriterTopic.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/WriterTopic.scala
@@ -176,7 +176,7 @@ private[stream] object WriterTopic {
 
     def getNext(p: Process[Task, I]) = {
       upState= Some(\/-(
-        p.runAsync({ actor ! Upstream(_) })(S)
+        p.stepAsync({ actor ! Upstream(_) })(S)
       ))
     }
 
@@ -234,7 +234,7 @@ private[stream] object WriterTopic {
         case Publish(_, cb)           => S(cb(-\/(rsn.asThrowable)))
         case Fail(_, cb)              => S(cb(\/-(())))
         case Upstream(-\/(_))         => //no-op
-        case Upstream(\/-((_, cont))) => S((Halt(Kill) +: cont).runAsync(_ => ()))
+        case Upstream(\/-((_, cont))) => S((Halt(Kill) +: cont) stepAsync { _ => () })
       })
     })(S)
 

--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -306,7 +306,7 @@ object io {
 
           case Step(Await(request, receive), cont) => {
             // yay! run the Task
-            cur = Util.Try(receive(EarlyCause(request.attempt.run)).run) +: cont
+            cur = Util.Try(receive(EarlyCause.fromTaskResult(request.attempt.run)).run) +: cont
             close()
           }
         }
@@ -341,7 +341,7 @@ object io {
 
           case Step(Await(request, receive), cont) => {
             // yay! run the Task
-            cur = Util.Try(receive(EarlyCause(request.attempt.run)).run) +: cont
+            cur = Util.Try(receive(EarlyCause.fromTaskResult(request.attempt.run)).run) +: cont
             step()    // push things onto the stack and then step further (tail recursively)
           }
         }

--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -184,13 +184,14 @@ package object nondeterminism {
 
         })(rsn => m match {
           //join is closed, next p is ignored and source is killed
-          case Offer(_, cont) =>  nextStep(Halt(Kill) +: cont)
+          case Offer(_, cont) => nextStep(Halt(Kill) +: cont)
           case FinishedSource(cause) => state = Either3.left3(cause) ; completeIfDone
           case Finished(_) => opened = opened - 1; completeIfDone
           case FinishedDown(cb) =>
             if (allDone) S(cb(\/-(())))
             else completer = Some(cb)
           case Start => ()
+          case Delay(cont) => nextStep(cont.continue)
         })
 
       })

--- a/src/main/scala/scalaz/stream/tcp.scala
+++ b/src/main/scala/scalaz/stream/tcp.scala
@@ -289,8 +289,11 @@ object tcp {
     def connect(ch: AsynchronousSocketChannel): Task[AsynchronousSocketChannel] =
       Task.async[AsynchronousSocketChannel] { cb =>
         ch.connect(to, null, new CompletionHandler[Void, Void] {
-          def completed(result: Void, attachment: Void): Unit = cb(right(ch))
-          def failed(rsn: Throwable, attachment: Void): Unit = cb(left(rsn))
+          def completed(result: Void, attachment: Void): Unit =
+            cb(right(ch))
+
+          def failed(rsn: Throwable, attachment: Void): Unit =
+            cb(left(rsn))
         })
       }
 
@@ -335,6 +338,7 @@ object tcp {
         sch.accept(null, new CompletionHandler[AsynchronousSocketChannel, Void] {
           def completed(result: AsynchronousSocketChannel, attachment: Void): Unit =
             S { cb(right(result)) }
+
           def failed(rsn: Throwable, attachment: Void): Unit =
             S { cb(left(rsn)) }
         })

--- a/src/main/scala/scalaz/stream/wye.scala
+++ b/src/main/scala/scalaz/stream/wye.scala
@@ -681,7 +681,7 @@ object wye {
       def runSide[A](side: Env[L, R]#Y[A])(state: SideState[A]): SideState[A] = state match {
         case Left3(rsn)         => a ! Ready[A](side, -\/(rsn)); state //just safety callback
         case Middle3(interrupt) => state //no-op already awaiting the result  //todo: don't wee nedd a calback there as well.
-        case Right3(cont)       => Either3.middle3(cont.continue.runAsync { res => a ! Ready[A](side, res) })
+        case Right3(cont)       => Either3.middle3(cont.continue stepAsync { res => a ! Ready[A](side, res) })
       }
 
       val runSideLeft = runSide(Left) _
@@ -698,7 +698,7 @@ object wye {
             Either3.middle3((_: Cause) => ()) //rest the interrupt so it won't get interrupted again
 
           case Right3(cont) =>
-            (Halt(Kill) +: cont).runAsync(_ => a ! Ready[A](side, -\/(Kill)))
+            (Halt(Kill) +: cont) stepAsync { _ => a ! Ready[A](side, -\/(Kill)) }
             Either3.middle3((_: Cause) => ()) // no-op cleanup can't be interrupted
 
           case left@Left3(_) =>

--- a/src/test/scala/scalaz/stream/MergeNSpec.scala
+++ b/src/test/scala/scalaz/stream/MergeNSpec.scala
@@ -32,11 +32,16 @@ object MergeNSpec extends Properties("mergeN") {
 
   }
 
+  property("complete-with-inner-finalizer") = secure {
+    merge.mergeN(emit(halt) onComplete eval_(Task now (()))).runLog timed 3000 run
+
+    true
+  }
+
 
   // tests that when downstream terminates,
   // all cleanup code is called on upstreams
   property("source-cleanup-down-done") = secure {
-
     val cleanupQ = async.boundedQueue[Int]()
     val cleanups = new SyncVar[Throwable \/ IndexedSeq[Int]]
 
@@ -49,6 +54,7 @@ object MergeNSpec extends Properties("mergeN") {
 
     // this makes sure we see at least one value from sources
     // and therefore we won`t terminate downstream to early.
+
     merge.mergeN(ps).scan(Set[Int]())({
       case (sum, next) => sum + next
     }).takeWhile(_.size < 10).runLog.timed(3000).run

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -317,7 +317,7 @@ object ProcessSpec extends Properties("Process") {
     Thread.sleep(200)     // ensure the task actually completes
 
     (result.get(3000).get == -\/(Kill)) :| "computation result" &&
-      (inner.get() == 0) :| "inner finalizer invocation count" &&
+      (inner.get() == 1) :| "inner finalizer invocation count" &&
       (outer.get() == 1) :| "outer finalizer invocation count"
   }
 

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -279,14 +279,14 @@ object ProcessSpec extends Properties("Process") {
     p.sequence(4).runLog.run == p.flatMap(eval).runLog.run
   }
 
-  property("runAsync onComplete on task never completing") = secure {
+  property("stepAsync onComplete on task never completing") = secure {
     val q = async.boundedQueue[Int]()
 
     @volatile var cleanupCalled = false
     val sync = new SyncVar[Cause \/ (Seq[Int], Process.Cont[Task,Int])]
     val p = q.dequeue onComplete eval_(Task delay { cleanupCalled = true })
 
-    val interrupt = p runAsync sync.put
+    val interrupt = p stepAsync sync.put
 
     Thread.sleep(100)
     interrupt(Kill)
@@ -294,7 +294,7 @@ object ProcessSpec extends Properties("Process") {
     sync.get(3000).isDefined :| "sync completion" && cleanupCalled :| "cleanup"
   }
 
-  property("runAsync independent onComplete exactly once on task eventually completing") = secure {
+  property("stepAsync independent onComplete exactly once on task eventually completing") = secure {
     val inner = new AtomicInteger(0)
     val outer = new AtomicInteger(0)
 
@@ -310,7 +310,7 @@ object ProcessSpec extends Properties("Process") {
       emit(42) onComplete (Process eval_ (Task delay { inner.incrementAndGet() }))
     } onComplete (Process eval_ (Task delay { outer.incrementAndGet() }))
 
-    val interrupt = p runAsync result.put
+    val interrupt = p stepAsync result.put
     signal.get
     interrupt(Kill)
 

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -317,8 +317,8 @@ object ProcessSpec extends Properties("Process") {
     Thread.sleep(200)     // ensure the task actually completes
 
     (result.get(3000).get == -\/(Kill)) :| "computation result" &&
-      (inner.get() == 1) :| "inner finalizer invocation count" &&
-      (outer.get() == 1) :| "outer finalizer invocation count"
+      (inner.get() == 1) :| s"inner finalizer invocation count ${inner.get()}" &&
+      (outer.get() == 1) :| s"outer finalizer invocation count ${outer.get()}"
   }
 
   property("Process0Syntax.toStream terminates") = secure {

--- a/src/test/scala/scalaz/stream/TcpSpec.scala
+++ b/src/test/scala/scalaz/stream/TcpSpec.scala
@@ -108,7 +108,7 @@ object TcpSpec extends Properties("tcp") {
       link.discrete.wye(server)(wye.interrupt)
           .run
           .runAsync { _.fold(e => throw e, identity) }
-    lazy val stopServer = { println("shutting down"); E.shutdown(); link.set(true).run }
+    lazy val stopServer = { E.shutdown(); link.set(true).run }
 
     property("setup") = forAll ((i: Int) => { startServer; true })
     property("go") =

--- a/src/test/scala/scalaz/stream/TcpSpec.scala
+++ b/src/test/scala/scalaz/stream/TcpSpec.scala
@@ -14,6 +14,7 @@ import scalaz.\/-
 import scalaz.concurrent.{Strategy,Task}
 import scalaz.stream.Process.Halt
 import scalaz.stream.ReceiveY._
+import scalaz.syntax.monad._
 import scodec.bits.ByteVector
 
 object TcpSpec extends Properties("tcp") {
@@ -94,20 +95,20 @@ object TcpSpec extends Properties("tcp") {
     val E = java.util.concurrent.Executors.newCachedThreadPool
     val S2 = Strategy.Executor(E)
 
-    lazy val server = Process.suspend {
+    lazy val server = {
       val topic = async.topic[String]()
       val chat =
         tcp.reads(1024).pipe(text.utf8Decode).to(topic.publish).wye {
           tcp.writes(tcp.lift(topic.subscribe.pipe(text.utf8Encode)))
         } (wye.mergeHaltBoth)
-      tcp.server(addr, concurrentRequests = 50)(chat).runLog.run.head
+      tcp.server(addr, concurrentRequests = 1)(chat) join     // TODO this should eventually go back to "not 1". frankly, I don't know how this is working at all even now
     }
     lazy val link = async.signalOf(false)
     lazy val startServer =
       link.discrete.wye(server)(wye.interrupt)
           .run
           .runAsync { _.fold(e => throw e, identity) }
-    lazy val stopServer = { E.shutdown(); link.set(true).run }
+    lazy val stopServer = { println("shutting down"); E.shutdown(); link.set(true).run }
 
     property("setup") = forAll ((i: Int) => { startServer; true })
     property("go") =

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -244,7 +244,7 @@ object WyeSpec extends  Properties("Wye"){
   //tests that wye correctly terminates drained process
   property("merge-drain-halt") = secure {
 
-    val effect:Process[Task,Int] = Process.repeatEval(Task.delay(())).drain
+    val effect:Process[Task,Int] = Process.repeatEval(Task delay { () }).drain
 
     val pm1 = effect.wye(Process(1000,2000).toSource)(wye.merge).take(2)
     val pm2 = Process(3000,4000).toSource.wye(effect)(wye.merge).take(2)

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -413,4 +413,12 @@ object WyeSpec extends  Properties("Wye"){
     val v = i1.wye(p2)(wye.interrupt).runLog.timed(3000).run.toList
     v.size >= 0
   }
+
+  property("interrupt-pipe with wye.merge") = secure {
+    val p1 = Process.constant(42).collect { case i if i < 0 => i } merge Process.constant(12)
+    val p2 = p1 |> process1.id
+    val i1 = Process(false)
+    val v = i1.wye(p2)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
 }

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -488,7 +488,7 @@ object WyeSpec extends  Properties("Wye"){
 
     val flag = new SyncVar[Unit]
 
-    val task1 = Task fork (Task delay { deadlocked = flag.get(2000).isEmpty; Thread.sleep(1000); complete = true })
+    val task1 = Task fork (Task delay { deadlocked = flag.get(10000).isEmpty; Thread.sleep(1000); complete = true })
     // val task1 = Task { deadlocked = flag.get(2000).isEmpty; Thread.sleep(1000); complete = true }
 
     val awaitP =  await(task1)(u =>Process.emit(u))

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -406,5 +406,11 @@ object WyeSpec extends  Properties("Wye"){
     v.size >= 0
   }
 
-
+  property("interrupt-pipe") = secure {
+    val p1 = Process.constant(42).collect { case i if i < 0 => i }
+    val p2 = p1 |> process1.id
+    val i1 = Process(false)
+    val v = i1.wye(p2)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
 }

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -364,5 +364,47 @@ object WyeSpec extends  Properties("Wye"){
 
   }
 
+  property("interrupt-constant.signal-halt") = secure {
+    val p1 = Process.constant(42)
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt-constant.signal-halt.collect-all") = secure {
+    val p1 = Process.constant(42).collect { case i if i > 0 => i }
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt-constant.signal-halt.collect-none") = secure {
+    val p1 = Process.constant(42).collect { case i if i < 0 => i }
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt-constant.signal-halt.filter-none") = secure {
+    val p1 = Process.constant(42).filter { _ < 0 }
+    val i1 = Process(false)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt-constant.signal-constant-true.collect-all") = secure {
+    val p1 = Process.constant(42).collect { case i if i > 0 => i }
+    val i1 = Process.constant(true)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
+  property("interrupt-constant.signal-constant-true.collect-none") = secure {
+    val p1 = Process.constant(42).collect { case i if i < 0 => i }
+    val i1 = Process.constant(true)
+    val v = i1.wye(p1)(wye.interrupt).runLog.timed(3000).run.toList
+    v.size >= 0
+  }
+
 
 }

--- a/src/test/scala/scalaz/stream/WyeSpec.scala
+++ b/src/test/scala/scalaz/stream/WyeSpec.scala
@@ -454,7 +454,7 @@ object WyeSpec extends  Properties("Wye"){
 
     val flag = new SyncVar[Unit]
 
-    val awaitP = await((Task delay { flag.get }) >> (Task delay {
+    val awaitP = await((Task delay { flag.get; Thread.sleep(500) }) >> (Task delay {
         Thread.sleep(3000)
         complete = true
       }))(emit)


### PR DESCRIPTION
This is a straight extension of #326, I just wanted to create a separate PR in order to keep the review clean.  I basically just cherry picked some commits from #318 and fixed the merge conflicts.  The result is a) more tests in `WyeSpec`, and b) a working `step` function!

BTW, I'd also like to petition we rename `runAsync` to `stepAsync`.  Its name implies that it runs the process all the way to the end, which is not at all what actually happens.