### PR TITLE
Updated to scodec-bits 1.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snap
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.0.6",
   "org.scalaz" %% "scalaz-concurrent" % "7.0.6",
-  "org.scodec" %% "scodec-bits" % "1.0.5",
+  "org.scodec" %% "scodec-bits" % "1.0.6",
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.0.6" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.1" % "test"
 )

--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -270,7 +270,7 @@ object io {
               val remaining = chunk.length - index
 
               if (length <= remaining) {
-                (chunk drop index take length).copyToArray(buffer, offset)      // TODO replace this with the 4-arg copyToArray once exposed
+                chunk.copyToArray(buffer, offset, index, length)
 
                 if (length == remaining) {
                   index = 0
@@ -281,7 +281,7 @@ object io {
 
                 length + read
               } else {
-                (chunk drop index take remaining).copyToArray(buffer, offset)      // TODO replace this with the 4-arg copyToArray once exposed
+                chunk.copyToArray(buffer, offset, index, remaining)
 
                 chunks = chunks.tail
                 go(offset + remaining, length - remaining, read + remaining)


### PR DESCRIPTION
Also modifies `io.toInputStream` to use the newly-exposed 4-arg `copyToArray` function, which improves efficiency quite nicely!  Special thanks to @mpilquist.