### PR TITLE
Feature/upgrade scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "snapshot-0.7"
 
 scalaVersion := "2.10.4"
 
-crossScalaVersions := Seq("2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.4", "2.11.6")
 
 scalacOptions ++= Seq(
   "-feature",

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "scalaz-stream"
 
 version := "snapshot-0.7"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.6"
 
-crossScalaVersions := Seq("2.10.4", "2.11.6")
+crossScalaVersions := Seq("2.10.5", "2.11.6")
 
 scalacOptions ++= Seq(
   "-feature",


### PR DESCRIPTION
In prep for 0.7 release:

Upgrades to scala 2.11.6 and 2.10.5.

Changes default scala version to 2.11.6.