### PR TITLE
Implemented batch dequeuing for async.Queue

### DIFF
--- a/src/main/scala/scalaz/stream/Exchange.scala
+++ b/src/main/scala/scalaz/stream/Exchange.scala
@@ -122,8 +122,8 @@ final case class Exchange[I, W](read: Process[Task, I], write: Sink[Task, W]) {
    * @param y WyeW to control queueing, flow control and transformation
    */
   def flow[I2,W2](y: WyeW[W, Int \/ I, W2, I2])(implicit S: Strategy): Exchange[I2, W2] = {
-    val wq = async.boundedQueue[W](0)
-    val w2q = async.boundedQueue[W2](0)
+    val wq = async.unboundedQueue[W]
+    val w2q = async.unboundedQueue[W2]
 
     def cleanup: Process[Task, Nothing] = eval_(wq.close) ++ eval_(w2q.close)
     def receive: Process[Task, I] = self.read onComplete cleanup
@@ -203,7 +203,7 @@ object Exchange {
     }
 
     await(Task.delay {
-      async.boundedQueue[W]()
+      async.unboundedQueue[W]
     })({ q =>
       val (out, np) = p.unemit
       val ex = Exchange[Nothing, W](halt, q.enqueue)

--- a/src/main/scala/scalaz/stream/async/mutable/Queue.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Queue.scala
@@ -199,15 +199,6 @@ private[stream] object Queue {
       }
     }
 
-    def dequeueOne(ref: ConsumerRef, cb: (Throwable \/ A => Unit)): Unit = {
-      dequeueBatch(ref, 1, {
-        case l @ -\/(_) => cb(l)
-        case \/-(Seq()) => dequeueOne(ref, cb)
-        case \/-(Seq(a)) => cb(\/-(a))
-        case \/-(_) => cb(-\/(new AssertionError("dequeueBatch exceeded limit")))
-      })
-    }
-
     def enqueueOne(as: Seq[A], cb: Throwable \/ Unit => Unit) = {
       import scalaz.stream.Util._
       queued = queued fast_++ as

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -9,29 +9,20 @@ package object async {
   /**
    * Creates bounded queue that is bound by supplied max size bound.
    * Please see [[scalaz.stream.async.mutable.Queue]] for more details.
-   * @param max maximum size of queue. When <= 0 (default) queue is unbounded
+   * @param max maximum size of queue (must be > 0)
    */
-  def boundedQueue[A](max: Int = 0)(implicit S: Strategy): Queue[A] =
-    Queue[A](max)
+  def boundedQueue[A](max: Int)(implicit S: Strategy): Queue[A] = {
+    if (max <= 0)
+      throw new IllegalArgumentException(s"queue bound must be greater than zero (got $max)")
+    else
+      Queue[A](max)
+  }
 
 
   /**
    * Creates unbounded queue. see [[scalaz.stream.async.mutable.Queue]] for more
    */
-  def unboundedQueue[A](implicit S: Strategy): Queue[A] =  boundedQueue(0)
-
-  /**
-   * Create a source that may be added to or halted asynchronously
-   * using the returned `Queue`. See `async.Queue`. As long as the
-   * `Strategy` is not `Strategy.Sequential`, enqueueing is
-   * guaranteed to take constant time, and consumers will be run on
-   * a separate logical thread.
-   */
-  @deprecated("Use async.unboundedQueue instead", "0.5.0")
-  def queue[A](implicit S: Strategy) : (Queue[A], Process[Task, A]) = {
-   val q = unboundedQueue[A]
-    (q,q.dequeue)
-  }
+  def unboundedQueue[A](implicit S: Strategy): Queue[A] = Queue[A](0)
 
   /**
    * Create a new continuous signal which may be controlled asynchronously.

--- a/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
+++ b/src/main/scala/scalaz/stream/nondeterminism/nondeterminism.scala
@@ -36,7 +36,11 @@ package object nondeterminism {
 
 
     suspend {
-      val q = async.boundedQueue[A](maxQueued)(S)
+      val q = if (maxQueued > 0)
+        async.boundedQueue[A](maxQueued)(S)
+      else
+        async.unboundedQueue[A](S)
+
       val done = async.signalOf(false)(S)
 
       //keep state of master source

--- a/src/test/scala/scalaz/stream/MergeNSpec.scala
+++ b/src/test/scala/scalaz/stream/MergeNSpec.scala
@@ -42,7 +42,7 @@ object MergeNSpec extends Properties("mergeN") {
   // tests that when downstream terminates,
   // all cleanup code is called on upstreams
   property("source-cleanup-down-done") = secure {
-    val cleanupQ = async.boundedQueue[Int]()
+    val cleanupQ = async.unboundedQueue[Int]
     val cleanups = new SyncVar[Throwable \/ IndexedSeq[Int]]
 
     val ps =
@@ -70,7 +70,7 @@ object MergeNSpec extends Properties("mergeN") {
   // unlike source-cleanup-down-done it focuses on situations where upstreams are in async state,
   // and thus will block until interrupted.
   property("source-cleanup-async-down-done") = secure {
-    val cleanupQ = async.boundedQueue[Int]()
+    val cleanupQ = async.unboundedQueue[Int]
     val cleanups = new SyncVar[Throwable \/ IndexedSeq[Int]]
     cleanupQ.dequeue.take(11).runLog.runAsync(cleanups.put)
 

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -170,7 +170,7 @@ object ProcessSpec extends Properties("Process") {
   }
 
   property("pipeIn") = secure {
-    val q = async.boundedQueue[String]()
+    val q = async.unboundedQueue[String]
     val sink = q.enqueue.pipeIn(process1.lift[Int,String](_.toString))
 
     (Process.range(0,10).toSource to sink).run.run
@@ -280,7 +280,7 @@ object ProcessSpec extends Properties("Process") {
   }
 
   property("stepAsync onComplete on task never completing") = secure {
-    val q = async.boundedQueue[Int]()
+    val q = async.unboundedQueue[Int]
 
     @volatile var cleanupCalled = false
     val sync = new SyncVar[Cause \/ (Seq[Int], Process.Cont[Task,Int])]

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -13,7 +13,7 @@ object QueueSpec extends Properties("queue") {
 
   property("basic") = forAll {
     l: List[Int] =>
-      val q = async.boundedQueue[Int]()
+      val q = async.unboundedQueue[Int]
       val t1 = Task {
         l.foreach(i => q.enqueueOne(i).run)
         q.close.run
@@ -32,7 +32,7 @@ object QueueSpec extends Properties("queue") {
 
   property("size-signal") = forAll {
     l: List[Int] =>
-      val q = async.boundedQueue[Int]()
+      val q = async.unboundedQueue[Int]
       val t1 = Task { l.foreach(i => q.enqueueOne(i).run) }
       val t2 = q.dequeue.runLog
       val t3 = q.size.discrete.runLog
@@ -66,7 +66,7 @@ object QueueSpec extends Properties("queue") {
 
   property("enqueue-distribution") = forAll {
     l: List[Int] =>
-      val q = async.boundedQueue[Int]()
+      val q = async.unboundedQueue[Int]
       val t1 = Task {
         l.foreach(i => q.enqueueOne(i).run)
         q.close.run
@@ -87,7 +87,7 @@ object QueueSpec extends Properties("queue") {
 
   property("closes-pub-sub") = secure {
     val l: List[Int] = List(1, 2, 3)
-    val q = async.boundedQueue[Int]()
+    val q = async.unboundedQueue[Int]
     val t1 = Task {
       l.foreach(i => q.enqueueOne(i).run)
       q.close.run
@@ -118,7 +118,7 @@ object QueueSpec extends Properties("queue") {
   // tests situation where killed process may `swallow` item in queue
   // from the process that is running
   property("queue-swallow-killed") = secure {
-    val q = async.boundedQueue[Int]()
+    val q = async.unboundedQueue[Int]
     val sleeper = time.sleep(1 second)
     val signalKill = Process(false).toSource ++ sleeper ++ Process(true)
 
@@ -130,7 +130,7 @@ object QueueSpec extends Properties("queue") {
   }
 
   property("dequeue-batch.basic") = forAll { l: List[Int] =>
-    val q = async.boundedQueue[Int]()
+    val q = async.unboundedQueue[Int]
     val t1 = Task {
       l.foreach(i => q.enqueueOne(i).run)
       q.close.run
@@ -148,7 +148,7 @@ object QueueSpec extends Properties("queue") {
   property("dequeue-batch.chunked") = secure {
     import Function.const
 
-    val q = async.boundedQueue[Int]()
+    val q = async.unboundedQueue[Int]
 
     val pump = for {
       chunk <- q.dequeueAvailable
@@ -168,7 +168,7 @@ object QueueSpec extends Properties("queue") {
   property("dequeue-batch.chunked-limited") = secure {
     import Function.const
 
-    val q = async.boundedQueue[Int]()
+    val q = async.unboundedQueue[Int]
 
     val pump = for {
       chunk <- q.dequeueBatch(2)

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -138,7 +138,7 @@ object QueueSpec extends Properties("queue") {
 
     val collected = new SyncVar[Throwable\/IndexedSeq[Seq[Int]]]
 
-    q.dequeueBatch().runLog.runAsync(collected.put)
+    q.dequeueAvailable.runLog.runAsync(collected.put)
     t1.runAsync(_=>())
 
     "Items were collected" |:  collected.get(3000).nonEmpty &&
@@ -151,7 +151,7 @@ object QueueSpec extends Properties("queue") {
     val q = async.boundedQueue[Int]()
 
     val pump = for {
-      chunk <- q.dequeueBatch()
+      chunk <- q.dequeueAvailable
       _ <- Process eval ((Process emitAll (0 until (chunk.length * 2) map const(chunk.length)) toSource) to q.enqueue).run     // do it in a sub-process to avoid emitting a lot of things
     } yield chunk
 

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -152,7 +152,7 @@ object QueueSpec extends Properties("queue") {
 
     val pump = for {
       chunk <- q.dequeueBatch()
-      _ <- Process eval (Process emitAll (0 until (chunk.length * 2) map const(chunk.length)) to q.enqueue).run     // do it in a sub-process to avoid emitting a lot of things
+      _ <- Process eval ((Process emitAll (0 until (chunk.length * 2) map const(chunk.length)) toSource) to q.enqueue).run     // do it in a sub-process to avoid emitting a lot of things
     } yield chunk
 
     val collected = new SyncVar[Throwable \/ IndexedSeq[Seq[Int]]]
@@ -172,7 +172,7 @@ object QueueSpec extends Properties("queue") {
 
     val pump = for {
       chunk <- q.dequeueBatch(2)
-      _ <- Process eval (Process emitAll (0 until (chunk.length * 2) map const(chunk.length)) to q.enqueue).run     // do it in a sub-process to avoid emitting a lot of things
+      _ <- Process eval ((Process emitAll (0 until (chunk.length * 2) map const(chunk.length)) toSource) to q.enqueue).run     // do it in a sub-process to avoid emitting a lot of things
     } yield chunk
 
     val collected = new SyncVar[Throwable \/ IndexedSeq[Seq[Int]]]


### PR DESCRIPTION
Satisfies #338.  Actually wasn't all that difficult.  The only downside I see is a *very* small constant-factor increase to the cost of dequeuing a single element (previously, the only supported use-case).  This factor comes from the boxing of that element inside a single-element list.  I'm not too concerned about it though, since all the other boxing utterly dwarfs this one addition.