### PR TITLE
Added special exception type for pre-step interrupt check

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -1239,6 +1239,8 @@ object Process extends ProcessInstances {
             case Step(awt: Await[Task, a, O], cont) => {
               val Await(req, rcv) = awt
 
+              case class PreStepAbort(c: EarlyCause) extends RuntimeException
+
               def unpack(msg: Option[Throwable \/ a]): Option[Process[Task, O]] = msg map { r => Try(rcv(EarlyCause fromTaskResult r).run) }
 
               // throws an exception if we're already interrupted (caught in preStep check)
@@ -1251,7 +1253,7 @@ object Process extends ProcessInstances {
                       checkInterrupt(int)
                   }
 
-                  case \/-(c) => Task fail Terminated(c)
+                  case \/-(c) => Task fail PreStepAbort(c)
                 }
               } join
 
@@ -1273,7 +1275,7 @@ object Process extends ProcessInstances {
                     completed: Process[Task, O] => Unit)(result: Option[Throwable \/ a]): Unit = result match {
 
                   // interrupted via the `Task.fail` defined in `checkInterrupt`
-                  case Some(-\/(Terminated(cause: EarlyCause))) => preStep(cause)
+                  case Some(-\/(PreStepAbort(cause: EarlyCause))) => preStep(cause)
 
                   case result => {
                     val inter = interrupted.get().toOption


### PR DESCRIPTION
I forgot to fix this before PRing bug/step.  Relying on `Terminated` is a pretty brittle hack.  The private exception type given here is unambiguous and cannot be thrown from the outside.  It's interesting to note that this is the second item to come out of the `stepAsync` code review with @viktorklang.  I just got so excited about the first item (the last race condition fix) that I forgot about the other one!