### PR TITLE
Make drain{O,W} consistent with Process.drain

### DIFF
--- a/src/main/scala/scalaz/stream/package.scala
+++ b/src/main/scala/scalaz/stream/package.scala
@@ -47,7 +47,7 @@ package object stream {
 
   /**
    * A `Writer[F,W,O]` is a `Process[F, W \/ O]`. See
-   * `Process.WriterSyntax` for convenience functions
+   * `WriterSyntax` for convenience functions
    * for working with either the written values (the `W`)
    * or the output values (the `O`).
    *

--- a/src/main/scala/scalaz/stream/writer.scala
+++ b/src/main/scala/scalaz/stream/writer.scala
@@ -33,19 +33,13 @@ object writer {
  */
 final class WriterSyntax[F[_], W, O](val self: Writer[F, W, O]) extends AnyVal {
 
-  /**
-   * Observe the output side of this `Writer` using the
-   * given `Sink`, then discard it. Also see `observeW`.
-   */
-  def drainO(snk: Sink[F, O]): Process[F, W] =
-    observeO(snk).stripO
+  /** Ignore the output side of this `Writer`. */
+  def drainO: Writer[F, W, Nothing] =
+    flatMapO(_ => halt)
 
-  /**
-   * Observe the write side of this `Writer` using the
-   * given `Sink`, then discard it. Also see `observeW`.
-   */
-  def drainW(snk: Sink[F, W]): Process[F, O] =
-    observeW(snk).stripW
+  /** Ignore the write side of this `Writer`. */
+  def drainW: Writer[F, Nothing, O] =
+    flatMapW(_ => halt)
 
   def flatMapO[F2[x] >: F[x], W2 >: W, B](f: O => Writer[F2, W2, B]): Writer[F2, W2, B] =
     self.flatMap(_.fold(emitW, f))

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -262,16 +262,6 @@ object ProcessSpec extends Properties("Process") {
     fallbackCausedBy == Some(Kill) && received.isEmpty
   }
 
-  property("pipeO stripW ~= stripW pipe") = forAll { (p1: Process1[Int,Int]) =>
-    val p = writer.logged(range(1, 11).toSource)
-    p.pipeO(p1).stripW.runLog.run == p.stripW.pipe(p1).runLog.run
-  }
-
-  property("pipeW stripO ~= stripO pipe") = forAll { (p1: Process1[Int,Int]) =>
-    val p = writer.logged(range(1, 11).toSource)
-    p.pipeW(p1).stripO.runLog.run == p.stripO.pipe(p1).runLog.run
-  }
-
   property("process.sequence returns elements in order") = secure {
     val random = util.Random
     val p = Process.range(1, 10).map(i => Task.delay { Thread.sleep(random.nextInt(100)); i })

--- a/src/test/scala/scalaz/stream/TestInstances.scala
+++ b/src/test/scala/scalaz/stream/TestInstances.scala
@@ -2,7 +2,7 @@ package scalaz.stream
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
-import scalaz.Equal
+import scalaz.{\/, Equal}
 import scalaz.std.anyVal._
 import scalaz.syntax.equal._
 import scalaz.concurrent.Task
@@ -80,6 +80,12 @@ object TestInstances {
     Arbitrary(Gen.oneOf(
       arbitrary[A].map(ReceiveL(_)),
       arbitrary[B].map(ReceiveR(_))
+    ))
+
+  implicit def arbitraryEither[A: Arbitrary, B: Arbitrary]: Arbitrary[A \/ B] =
+    Arbitrary(Gen.oneOf(
+      arbitrary[A].map(\/.left),
+      arbitrary[B].map(\/.right)
     ))
 
   implicit def equalProcess0[A: Equal]: Equal[Process0[A]] =

--- a/src/test/scala/scalaz/stream/WriterSpec.scala
+++ b/src/test/scala/scalaz/stream/WriterSpec.scala
@@ -1,0 +1,31 @@
+package scalaz.stream
+
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+import scalaz.std.anyVal._
+import scalaz.stream.Process._
+import scalaz.stream.TestInstances._
+import scalaz.syntax.equal._
+
+object WriterSpec extends Properties("Writer") {
+  property("drainO ~= liftW . stripO") = forAll { w0: Writer[Nothing, Char, Int] =>
+    val w = w0.toSource
+    w.drainO.runLog.run == writer.liftW(w.stripO).runLog.run
+  }
+
+  property("drainW ~= liftO . stripW") = forAll { w0: Writer[Nothing, Char, Int] =>
+    val w = w0.toSource
+    w.drainW.runLog.run == writer.liftO(w.stripW).runLog.run
+  }
+
+  property("pipeO stripW ~= stripW pipe") = forAll { (p1: Process1[Int,Int]) =>
+    val p = writer.logged(range(1, 11).toSource)
+    p.pipeO(p1).stripW === p.stripW.pipe(p1)
+  }
+
+  property("pipeW stripO ~= stripO pipe") = forAll { (p1: Process1[Int,Int]) =>
+    val p = writer.logged(range(1, 11).toSource)
+    p.pipeW(p1).stripO === p.stripO.pipe(p1)
+  }
+}

--- a/src/test/scala/scalaz/stream/examples/WritingAndLogging.scala
+++ b/src/test/scala/scalaz/stream/examples/WritingAndLogging.scala
@@ -11,7 +11,7 @@ object WritingAndLogging extends Properties("writing-and-logging") {
   /*
 
   A `Writer[F,W,O]` is a `Process[F, W \/ O]`. See
-  `Process.WriterSyntax` for convenience functions
+  `WriterSyntax` for convenience functions
   for working with either the written values (the `W`)
   or the output values (the `O`).
 
@@ -46,7 +46,8 @@ object WritingAndLogging extends Properties("writing-and-logging") {
       Process.range(0,10)
              .flatMap(i => P.tell("Got input: " + i) ++ P.emitO(i))
              .toSource
-             .drainW(io.fillBuffer(buf))
+             .observeW(io.fillBuffer(buf))
+             .stripW
 
     /* This will have the side effect of filling `buf`. */
     ex.run.run
@@ -82,14 +83,14 @@ object WritingAndLogging extends Properties("writing-and-logging") {
     val snk2: Sink[Task,String] = io.stdOutLines
 
     /*
-    The `drainW` function observes the write values of
-    a `Writer` using some `Sink`, and then discards the
-    write side of the writer to get back an ordinary
-    `Process`. Notice the `Int` output is still available
-    for further transformation.
+    The `observeW` function observes the write values of
+    a `Writer` using some `Sink`, and then the `stripW`
+    function discards the write side of the writer to get
+    back an ordinary `Process`. Notice the `Int` output
+    is still available for further transformation.
     */
     val step2: Process[Task,Int] =
-      step1.drainW(snk)
+      step1.observeW(snk).stripW
 
     /* Make sure all values got written to the buffer. */
     buf.toList == List.range(0,10).map("Got input: " + _)


### PR DESCRIPTION
This PR fixes #344. In its current form it just changes `drainO` and `drainW` to be consistent with `Process.drain`.