### PR TITLE
Use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ scalaz-stream
 To get the latest version of the library, add the following to your SBT build:
 
 ``` scala
-resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
+resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
 ```
 
 And use one of the following library dependencies:


### PR DESCRIPTION
HTTPS is available:

https://dl.bintray.com/scalaz/releases/

Incidentally, I really prefer to not have to add a new resolver with every new library I encounter. Is it possible to get this synced to Maven Central? This makes even more sense since SBT downloads from Maven Central _with HTTPS_ by default.