### PR TITLE
Circular buffers

### DIFF
--- a/src/main/scala/scalaz/stream/async/mutable/Queue.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Queue.scala
@@ -108,11 +108,6 @@ trait Queue[A] {
 }
 
 private[stream] object CircularBuffer {
-  /**
-   * Builds a queue that functions as a circular buffer. Up to `bound` elements of
-   * type `A` will accumulate on the queue and then it will begin overwriting
-   * the oldest elements. Thus an enqueue process will never wait.
-   */
   def apply[A](bound: Int)(implicit S: Strategy): Queue[A] =
     Queue.mk(bound, (as, q) => if (as.size + q.size > bound) q.drop(as.size) else q)
 }

--- a/src/main/scala/scalaz/stream/async/mutable/Queue.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Queue.scala
@@ -107,9 +107,12 @@ trait Queue[A] {
   private[stream] def failWithCause(c:Cause): Task[Unit]
 }
 
+private[stream] object CircularBuffer {
+  def apply[A](bound: Int)(implicit S: Strategy): Queue[A] =
+    Queue.mk(bound, (as, q) => if (as.size + q.size > bound) q.drop(as.size) else q)
+}
 
 private[stream] object Queue {
-
   /**
    * Builds a queue, potentially with `source` producing the streams that
    * will enqueue into queue. Up to `bound` size of `A` may enqueue into queue,
@@ -119,8 +122,11 @@ private[stream] object Queue {
    * @tparam A
    * @return
    */
-  def apply[A](bound: Int = 0)(implicit S: Strategy): Queue[A] = {
+  def apply[A](bound: Int = 0)(implicit S: Strategy): Queue[A] =
+    mk(bound, (_, q) => q)
 
+  def mk[A](bound: Int,
+            beforeEnqueue: (Seq[A], Vector[A]) => Vector[A])(implicit S: Strategy): Queue[A] = {
     sealed trait M
     case class Enqueue(a: Seq[A], cb: Throwable \/ Unit => Unit) extends M
     case class Dequeue(ref: ConsumerRef, limit: Int, cb: Throwable \/ Seq[A] => Unit) extends M
@@ -210,6 +216,7 @@ private[stream] object Queue {
     }
 
     def enqueueOne(as: Seq[A], cb: Throwable \/ Unit => Unit) = {
+      queued = beforeEnqueue(as, queued)
       import scalaz.stream.Util._
       queued = queued fast_++ as
 

--- a/src/main/scala/scalaz/stream/async/mutable/Queue.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Queue.scala
@@ -108,6 +108,11 @@ trait Queue[A] {
 }
 
 private[stream] object CircularBuffer {
+  /**
+   * Builds a queue that functions as a circular buffer. Up to `bound` elements of
+   * type `A` will accumulate on the queue and then it will begin overwriting
+   * the oldest elements. Thus an enqueue process will never wait.
+   */
   def apply[A](bound: Int)(implicit S: Strategy): Queue[A] =
     Queue.mk(bound, (as, q) => if (as.size + q.size > bound) q.drop(as.size) else q)
 }
@@ -115,7 +120,7 @@ private[stream] object CircularBuffer {
 private[stream] object Queue {
   /**
    * Builds a queue, potentially with `source` producing the streams that
-   * will enqueue into queue. Up to `bound` size of `A` may enqueue into queue,
+   * will enqueue into queue. Up to `bound` number of `A` may enqueue into the queue,
    * and then all enqueue processes will wait until dequeue.
    *
    * @param bound   Size of the bound. When <= 0 the queue is `unbounded`.
@@ -207,7 +212,7 @@ private[stream] object Queue {
 
         queued = remainder
         signalSize(queued.size)
-        if (unAcked.size > 0 && bound > 0 && queued.size < bound) {
+        if (unAcked.size > 0 && bound > 0 && queued.size <= bound) {
           val ackCount = bound - queued.size min unAcked.size
           unAcked.take(ackCount).foreach(cb => S(cb(\/-(()))))
           unAcked = unAcked.drop(ackCount)
@@ -230,7 +235,7 @@ private[stream] object Queue {
         queued = queued.drop(deqCount)
       }
 
-      if (bound > 0 && queued.size >= bound) unAcked = unAcked :+ cb
+      if (bound > 0 && queued.size > bound) unAcked = unAcked :+ cb
       else S(cb(\/-(())))
 
       signalSize(queued.size)

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -26,8 +26,9 @@ package object async {
   def unboundedQueue[A](implicit S: Strategy): Queue[A] = Queue[A](0)
 
   /**
-   * Creates a bounded queue that functions as a circular buffer.
-   * See [[scalaz.stream.async.mutable.CircularBuffer]] for more details.
+   * Builds a queue that functions as a circular buffer. Up to `bound` elements of
+   * type `A` will accumulate on the queue and then it will begin overwriting
+   * the oldest elements. Thus an enqueue process will never wait.
    * @param size The size of the circular buffer (must be > 0)
    */
   def circularBuffer[A](size: Int)(implicit S: Strategy): Queue[A] = CircularBuffer[A](size)

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -9,9 +9,9 @@ import scalaz.\/._
 package object async {
 
   /**
-   * Creates bounded queue that is bound by supplied max size bound.
+   * Creates a bounded queue that is bound by supplied max size bound.
    * Please see [[scalaz.stream.async.mutable.Queue]] for more details.
-   * @param max maximum size of queue (must be > 0)
+   * @param max The maximum size of the queue (must be > 0)
    */
   def boundedQueue[A](max: Int)(implicit S: Strategy): Queue[A] = {
     if (max <= 0)
@@ -21,11 +21,16 @@ package object async {
   }
 
   /**
-   * Creates unbounded queue. see [[scalaz.stream.async.mutable.Queue]] for more
+   * Creates an unbounded queue. see [[scalaz.stream.async.mutable.Queue]] for more
    */
   def unboundedQueue[A](implicit S: Strategy): Queue[A] = Queue[A](0)
 
-  def circularBuffer[A](bound: Int)(implicit S: Strategy): Queue[A] = CircularBuffer[A](bound)
+  /**
+   * Creates a bounded queue that functions as a circular buffer.
+   * See [[scalaz.stream.async.mutable.CircularBuffer]] for more details.
+   * @param size The size of the circular buffer (must be > 0)
+   */
+  def circularBuffer[A](size: Int)(implicit S: Strategy): Queue[A] = CircularBuffer[A](size)
 
   /**
    * Create a new continuous signal which may be controlled asynchronously.

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -20,11 +20,12 @@ package object async {
       Queue[A](max)
   }
 
-
   /**
    * Creates unbounded queue. see [[scalaz.stream.async.mutable.Queue]] for more
    */
   def unboundedQueue[A](implicit S: Strategy): Queue[A] = Queue[A](0)
+
+  def circularBuffer[A](bound: Int)(implicit S: Strategy): Queue[A] = CircularBuffer[A](bound)
 
   /**
    * Create a new continuous signal which may be controlled asynchronously.

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -26,7 +26,7 @@ package object async {
   def unboundedQueue[A](implicit S: Strategy): Queue[A] = Queue[A](0)
 
   /**
-   * Builds a queue that functions as a circular buffer. Up to `bound` elements of
+   * Builds a queue that functions as a circular buffer. Up to `size` elements of
    * type `A` will accumulate on the queue and then it will begin overwriting
    * the oldest elements. Thus an enqueue process will never wait.
    * @param size The size of the circular buffer (must be > 0)

--- a/src/main/scala/scalaz/stream/sink.scala
+++ b/src/main/scala/scalaz/stream/sink.scala
@@ -17,7 +17,6 @@ final class SinkSyntax[F[_], I](val self: Sink[F, I]) extends AnyVal {
   /** Converts `Sink` to `Channel`, that will perform the side effect and echo its input. */
   def toChannel(implicit F: Functor[F]): Channel[F, I, I] =
     self.map(f => (i: I) => f(i).as(i))
-
 }
 
 final class SinkTaskSyntax[I](val self: Sink[Task, I]) extends AnyVal {

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -1,8 +1,8 @@
 package scalaz.stream
 
 import Cause._
+import org.scalacheck.{Gen, Properties, Arbitrary}
 import org.scalacheck.Prop._
-import org.scalacheck.Properties
 import scala.concurrent.SyncVar
 import scalaz.concurrent.Task
 import scalaz.{-\/, \/-, \/}
@@ -10,6 +10,23 @@ import scala.concurrent.duration._
 
 object QueueSpec extends Properties("queue") {
   implicit val scheduler = scalaz.stream.DefaultScheduler
+
+  property("circular-buffer") = forAll(Gen.posNum[Int], implicitly[Arbitrary[List[Int]]].arbitrary) {
+    (bound: Int, xs: List[Int]) =>
+      val b = async.circularBuffer[Int](bound)
+      val collected = new SyncVar[Throwable\/IndexedSeq[Int]]
+      val p = (Process.emitAll(xs) to b.enqueue).run.timed(3000).attempt.run
+      b.dequeue.runLog.runAsync(collected.put)
+      b.close.run
+      val ys = collected.get(3000).map(_.getOrElse(Nil)).getOrElse(Nil)
+      b.close.runAsync(_ => ())
+
+      ("Enqueue process is not blocked" |: p.isRight)
+      ("Dequeued a suffix of the input" |: (xs endsWith ys)) &&
+      ("No larger than the bound" |: (ys.length <= bound)) &&
+      (s"Exactly as large as the bound (got ${ys.length})" |:
+        (xs.length < bound && ys.length == xs.length || ys.length == bound))
+  }
 
   property("basic") = forAll {
     l: List[Int] =>
@@ -184,4 +201,5 @@ object QueueSpec extends Properties("queue") {
     collected.get(5000).nonEmpty :| "items were collected" &&
       ((collected.get getOrElse Nil) == Seq(Seq(1), Seq(1, 1), Seq(2, 2), Seq(2, 2), Seq(2, 2))) :| s"saw ${collected.get getOrElse Nil}"
   }
+
 }

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -15,7 +15,7 @@ object QueueSpec extends Properties("queue") {
     (bound: Int, xs: List[Int]) =>
       val b = async.circularBuffer[Int](bound)
       val collected = new SyncVar[Throwable\/IndexedSeq[Int]]
-      val p = (Process.emitAll(xs) to b.enqueue).run.timed(3000).attempt.run
+      val p = ((Process.emitAll(xs):Process[Task,Int]) to b.enqueue).run.timed(3000).attempt.run
       b.dequeue.runLog.runAsync(collected.put)
       b.close.run
       val ys = collected.get(3000).map(_.getOrElse(Nil)).getOrElse(Nil)


### PR DESCRIPTION
Adds circular buffers.

I believe this also fixes an off-by-one error in async.Queue, where the queue will begin blocking producers at size `bound - 1` rather than `bound`. And if the queue size was at `bound`, it would have to be dequeued twice to see any results.

Review by @pchlupacek appreciated.