### PR TITLE
Implemented sbt-git

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ git.gitTagToVersionNumber := {
   case _ => None
 }
 
-// git.formattedShaVersion := git.gitHeadCommit.value      // bintray really hates -SNAPSHOT versions, so we just use the hash
-
 scalaVersion := "2.11.6"
 
 crossScalaVersions := Seq("2.10.5", "2.11.6")

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,16 @@
+enablePlugins(GitVersioning)
+
 organization := "org.scalaz.stream"
 
 name := "scalaz-stream"
 
-version := "snapshot-0.7"
+val ReleaseTag = """^release/([\d\.]+a?)$""".r
+git.gitTagToVersionNumber := {
+  case ReleaseTag(version) => Some(version)
+  case _ => None
+}
+
+git.formattedShaVersion := git.gitHeadCommit.value      // bintray really hates -SNAPSHOT versions, so we just use the hash
 
 scalaVersion := "2.11.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ git.gitTagToVersionNumber := {
   case _ => None
 }
 
-git.formattedShaVersion := git.gitHeadCommit.value      // bintray really hates -SNAPSHOT versions, so we just use the hash
+// git.formattedShaVersion := git.gitHeadCommit.value      // bintray really hates -SNAPSHOT versions, so we just use the hash
 
 scalaVersion := "2.11.6"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,6 @@ resolvers += Resolver.url(
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.0")
 
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.3")


### PR DESCRIPTION
Remember that, in SBT, `version` is a `SettingKey` and not a `TaskKey`, meaning that the value is computed *once* and not recomputed until reload!  Thus, if you make a new commit, tag or otherwise do something that *should* modify the value of `version`, you need to `reload` to see it take effect.

When in doubt, `show version`.