### PR TITLE
Add `localAddress` method to `tcp` and `udp` modules

### DIFF
--- a/src/main/scala/scalaz/stream/tcp.scala
+++ b/src/main/scala/scalaz/stream/tcp.scala
@@ -45,6 +45,9 @@ object tcp {
     /** Ask for the remote address of the peer. */
     def remoteAddress: Task[InetSocketAddress]
 
+    /** Ask for the local address of the socket. */
+    def localAddress: Task[InetSocketAddress]
+
     /**
      * Write `bytes` to the peer. If `timeout` is provided
      * and the operation does not complete in the specified duration,
@@ -93,6 +96,14 @@ object tcp {
         // "Where the channel is bound and connected to an Internet Protocol socket
         // address then the return value from this method is of type InetSocketAddress."
         channel.getRemoteAddress().asInstanceOf[InetSocketAddress]
+      }
+
+    def localAddress: Task[InetSocketAddress] =
+      Task.delay {
+        // NB: This cast is safe because, from the javadoc:
+        // "Where the channel is bound and connected to an Internet Protocol socket
+        // address then the return value from this method is of type InetSocketAddress."
+        channel.getLocalAddress().asInstanceOf[InetSocketAddress]
       }
 
     def write(bytes: ByteVector,
@@ -168,6 +179,10 @@ object tcp {
   /** Returns a single-element stream containing the remote address of the peer. */
   def remoteAddress: Process[Connection,InetSocketAddress] =
     ask.flatMap { e => eval(e.remoteAddress) }
+
+  /** Returns a single-element stream containing the local address of the connection. */
+  def localAddress: Process[Connection,InetSocketAddress] =
+    ask.flatMap { e => eval(e.localAddress) }
 
   /** Indicate to the peer that we are done writing. */
   def eof: Process[Connection,Nothing] =

--- a/src/main/scala/scalaz/stream/udp.scala
+++ b/src/main/scala/scalaz/stream/udp.scala
@@ -45,6 +45,10 @@ object udp {
   def merge[A](a: Process[Connection,A], a2: Process[Connection,A])(implicit S: Strategy): Process[Connection,A] =
     wye(a,a2)(scalaz.stream.wye.merge)
 
+  /** Returns a single-element stream containing the local address of the bound socket. */
+  def localAddress: Process[Connection,InetSocketAddress] =
+    ask.flatMap { d => eval(Task.delay(d.getLocalSocketAddress.asInstanceOf[InetSocketAddress])) }
+
   /**
    * Receive a single UDP [[Packet]]. `maxPacketSize` controls the maximum
    * number of bytes in the received. See `java.net.DatagramSocket#receive`


### PR DESCRIPTION
Motivation is binding to port 0 and accessing the bound port number.