### PR TITLE
Implemented scan through State process1

### DIFF
--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -1061,6 +1061,10 @@ private[stream] trait Process1Ops[+F[_],+O] {
   def scan[B](b: B)(f: (B,O) => B): Process[F,B] =
     this |> process1.scan(b)(f)
 
+  /** Alias for `this |> [[process1.stateScan]](init)(f)`. */
+  def stateScan[S, B](init: S)(f: O => State[S, B]): Process[F, B] =
+    this |> process1.stateScan(init)(f)
+
   /** Alias for `this |> [[process1.scanMap]](f)(M)`. */
   def scanMap[M](f: O => M)(implicit M: Monoid[M]): Process[F,M] =
     this |> process1.scanMap(f)(M)

--- a/src/main/scala/scalaz/stream/process1.scala
+++ b/src/main/scala/scalaz/stream/process1.scala
@@ -540,6 +540,13 @@ object process1 {
       case \/-(a)   => emit(a)
     }
 
+  def stateScan[S, A, B](init: S)(f: A => State[S, B]): Process1[A, B] = {
+    await1[A] flatMap { a =>
+      val (s, b) = f(a) run init
+      emit(b) ++ stateScan(s)(f)
+    }
+  }
+
   /**
    * Similar to List.scan.
    * Produces a process of `B` containing cumulative results of applying the operator to Process of `A`.


### PR DESCRIPTION
Adds a process1 with the following type signature:

```scala
def stateScan[S, A, B](init: S)(f: A => State[S, B]): Process1[A, B]
```

I've wanted this for a while, and it is in general much more usable than `scan` despite serving essentially the same purpose.  Decided to relax by scratching my own itch.