### PR TITLE
Add process1.mapAccumulate as discussed in #309

### DIFF
--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -74,6 +74,10 @@ class Process1Spec extends Properties("Process1") {
           val lifted = process1.liftR[Nothing,Int,Int](process1.id[Int].map( i=> i + 1) onComplete emit(Int.MinValue))
           pi.map(\/-(_)).pipe(lifted).toList == li.map(i => \/-(i + 1)) :+ \/-(Int.MinValue)
         }
+        , "mapAccumulate" |: {
+          val r = pi.mapAccumulate(0)((s, i) => (s + i, f(i))).toList
+          r.map(_._1) === li.scan(0)(_ + _).tail && r.map(_._2) === li.map(f)
+        }
         , "maximum" |: pi.maximum.toList === li.maximum.toList
         , "maximumBy" |: {
           // enable when switching to scalaz 7.1


### PR DESCRIPTION
This adds
```scala
def mapAccumulate[S, A, B](init: S)(f: (S, A) => (S, B)): Process1[A, (S, B)]
```
to `process1` as discussed in #309.