### PR TITLE
Recover lost data in Queue

### DIFF
--- a/src/main/scala/scalaz/stream/async/mutable/Queue.scala
+++ b/src/main/scala/scalaz/stream/async/mutable/Queue.scala
@@ -294,22 +294,7 @@ private[stream] object Queue {
         case GetSize(cb)                         => signalClosed(cb)
         case Fail(_, cb)                         => S(cb(\/-(())))
 
-        case ConsumerDone(ref)                   => {
-          consumers = consumers.filterNot(_._1 == ref)
-
-          if (ref.lastBatch.nonEmpty) {
-            if (queued.isEmpty) {
-              val batch = ref.lastBatch
-              ref.lastBatch = Vector.empty[A]
-
-              enqueueOne(batch, Function.const(()))     // we don't actually care about the callback; it'll happen eventually
-            } else {
-              queued = ref.lastBatch fast_++ queued
-              ref.lastBatch = Vector.empty[A]
-              signalSize(queued.size)
-            }
-          }
-        }
+        case ConsumerDone(ref)                   => consumers = consumers.filterNot(_._1 == ref)
       }
     })(S)
 

--- a/src/main/scala/scalaz/stream/async/package.scala
+++ b/src/main/scala/scalaz/stream/async/package.scala
@@ -12,18 +12,24 @@ package object async {
    * Creates a bounded queue that is bound by supplied max size bound.
    * Please see [[scalaz.stream.async.mutable.Queue]] for more details.
    * @param max The maximum size of the queue (must be > 0)
+   * @param recover Flag controlling automatic dequeue error recovery semantics.  When
+   * false (the default), data may be lost in the event of an error during dequeue.
+   * When true, data will never be lost on dequeue, but concurrent dequeue processes
+   * may see data out of order under certain error conditions.
    */
-  def boundedQueue[A](max: Int)(implicit S: Strategy): Queue[A] = {
+  def boundedQueue[A](max: Int, recover: Boolean = false)(implicit S: Strategy): Queue[A] = {
     if (max <= 0)
       throw new IllegalArgumentException(s"queue bound must be greater than zero (got $max)")
     else
-      Queue[A](max)
+      Queue[A](max, recover)
   }
 
   /**
    * Creates an unbounded queue. see [[scalaz.stream.async.mutable.Queue]] for more
    */
   def unboundedQueue[A](implicit S: Strategy): Queue[A] = Queue[A](0)
+
+  def unboundedQueue[A](recover: Boolean)(implicit S: Strategy): Queue[A] = Queue[A](0, recover)
 
   /**
    * Builds a queue that functions as a circular buffer. Up to `size` elements of

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -227,4 +227,17 @@ class QueueSpec extends Properties("queue") {
       (results == xs) :| s"got $results"
     }
   }
+
+  property("dequeue.take-1-repeatedly") = secure {
+    val q = async.unboundedQueue[Int]
+    q.enqueueAll(List(1, 2, 3)).run
+
+    val p = for {
+      i1 <- q.dequeue take 1
+      i2 <- q.dequeue take 1
+      i3 <- q.dequeue take 1
+    } yield List(i1, i2, i3)
+
+    p.runLast.run == Some(List(1, 2, 3))
+  }
 }

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -204,7 +204,7 @@ class QueueSpec extends Properties("queue") {
 
   property("dequeue.preserve-data-in-error-cases") = forAll { xs: List[Int] =>
     xs.nonEmpty ==> {
-      val q = async.unboundedQueue[Int]
+      val q = async.unboundedQueue[Int](true)
       val hold = new SyncVar[Unit]
 
       val setup = (Process emitAll xs toSource) to q.enqueue run

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -207,7 +207,7 @@ class QueueSpec extends Properties("queue") {
       val q = async.unboundedQueue[Int]
       val hold = new SyncVar[Unit]
 
-      val setup = Process emitAll xs to q.enqueue run
+      val setup = (Process emitAll xs toSource) to q.enqueue run
 
       val driver = q.dequeue to (Process fail (new RuntimeException("whoops"))) onComplete (Process eval_ (Task delay { hold.put(()) }))
 

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -203,23 +203,28 @@ class QueueSpec extends Properties("queue") {
   }
 
   property("dequeue.preserve-data-in-error-cases") = forAll { xs: List[Int] =>
-    val q = async.unboundedQueue[Int]
+    xs.nonEmpty ==> {
+      val q = async.unboundedQueue[Int]
+      val hold = new SyncVar[Unit]
 
-    val setup = for {
-      _ <- (Process emitAll xs to q.enqueue run)
-      _ <- q.close
-    } yield ()
+      val setup = Process emitAll xs to q.enqueue run
 
-    val driver = q.dequeue to (Process fail (new RuntimeException("whoops")))
+      val driver = q.dequeue to (Process fail (new RuntimeException("whoops"))) onComplete (Process eval_ (Task delay { hold.put(()) }))
 
-    val safeDriver = driver onHalt {
-      case Error(_) => Process.Halt(End)
-      case rsn => Process.Halt(rsn)
+      val safeDriver = driver onHalt {
+        case Error(_) => Process.Halt(End)
+        case rsn => Process.Halt(rsn)
+      }
+
+      val recovery = for {
+        _ <- Process eval (Task delay { hold.get })
+        i <- q.dequeue take xs.length
+      } yield i
+
+      setup.run
+
+      val results = (safeDriver merge recovery).runLog.timed(3000).run
+      (results == xs) :| s"got $results"
     }
-
-    setup.run
-
-    val results = (safeDriver merge q.dequeue).runLog.run
-    (results == xs) :| s"got $results"
   }
 }


### PR DESCRIPTION
This fixes data lost by premature closure of the `dequeue` process, giving users a chance to run a fresh `dequeue` that recovers from the failure.  There *is* a tradeoff here though, and that tradeoff is that we may see data multiple times.  We can't really be absolutely sure that a premature closure of `dequeue` is an error, and so we over-approximate by just pushing the data back in regardless (we may be able to do better here once we address #288).  Given the way in which queues are generally used (i.e. often connected to external data sources, such as network sockets), I don't think this limitation is too much of a problem.  If you *really* need to ensure that you don't see repeated data from fresh dequeues, you should run an LRU deduplicating cache.

Note that this *also* slightly changes the semantics of multiple concurrent "dequeuers".  If you're dequeuing from multiple processes simultaneously, not only is it somewhat non-deterministic as to which process gets which value, but these processes may see data *out of order* relative to each other!  This happens if one of the two dequeuers ends prematurely.  The last batch of data seen by the ended dequeuer will get sent over to the other process, which may *in the meantime* have seen some data that was enqueued after the last batch from the failed dequeuer.  Thus, ordering constraints are violated, but *only* if you have multiple concurrent dequeues.  In other words, a case that already results in significant nondeterminism.