### PR TITLE
Removed auto-magical Terminated coercion in eval/repeatEval

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -983,7 +983,7 @@ object Process extends ProcessInstances {
   implicit class ProcessSyntax[F[_],O](val self: Process[F,O]) extends AnyVal {
     /** Feed this `Process` through the given effectful `Channel`. */
     def through[F2[x]>:F[x],O2](f: Channel[F2,O,O2]): Process[F2,O2] =
-        self.zipWith(f)((o,f) => f(o)).eval
+        self.zipWith(f)((o,f) => f(o)).eval onHalt { _.asHalt }     // very gross; I don't like this, but not sure what to do
 
     /**
      * Feed this `Process` through the given effectful `Channel`, signaling
@@ -1015,16 +1015,8 @@ object Process extends ProcessInstances {
      * be evaluated before work begins on producing the next `F`
      * action. To allow for concurrent evaluation, use `sequence`
      * or `gather`.
-     *
-     * If evaluation of `F` results to `Terminated(cause)`
-     * the evaluation of the stream is terminated with `cause`
      */
-    def eval: Process[F, O] = {
-      self.flatMap(f=> await(f)(emit)).onHalt {
-        case Error(Terminated(cause)) => Halt(cause)
-        case cause => Halt(cause)
-      }
-    }
+    def eval: Process[F, O] = self flatMap { await(_)(emit) }
 
     /**
      * Read chunks of `bufSize` from input, then use `Nondeterminism.gatherUnordered`
@@ -1406,13 +1398,9 @@ object Process extends ProcessInstances {
   /////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Evaluate an arbitrary effect in a `Process`. The resulting
-   * `Process` emits a single value. To evaluate repeatedly, use
-   * `repeatEval(t)`.
-   * Do not use `eval.repeat` or  `repeat(eval)` as that may cause infinite loop in certain situations.
+   * Alias for await(fo)(emit)
    */
-  def eval[F[_], O](f: F[O]): Process[F, O] =
-    awaitOr(f)(_.asHalt)(emit)
+  def eval[F[_], O](fo: F[O]): Process[F, O] = await(fo)(emit)
 
   /**
    * Evaluate an arbitrary effect once, purely for its effects,
@@ -1427,14 +1415,10 @@ object Process extends ProcessInstances {
 
   /**
    * Evaluate an arbitrary effect in a `Process`. The resulting `Process` will emit values
-   * until evaluation of `f` signals termination with `End` or an error occurs.
-   *
-   * Note that if `f` results to failure of type `Terminated` the repeatEval will convert cause
-   * to respective process cause termination, and will halt with that cause.
+   * until an error occurs.
    *
    */
-  def repeatEval[F[_], O](f: F[O]): Process[F, O] =
-    awaitOr(f)(_.asHalt)(o => emit(o) ++ repeatEval(f))
+  def repeatEval[F[_], O](fo: F[O]): Process[F, O] = eval(fo).repeat
 
   /**
    * Produce `p` lazily. Useful if producing the process involves allocation of

--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -152,7 +152,7 @@ object io {
                          step: R => F[O]): Process[F,O] =
     await(acquire) { r =>
       repeatEval(step(r)).onComplete(eval_(release(r)))
-    }
+    } onHalt { _.asHalt }
 
   /**
    * The standard input stream, as `Process`. This `Process` repeatedly awaits
@@ -166,7 +166,7 @@ object io {
    * and emits lines from standard input.
    */
   def stdInLines: Process[Task,String] =
-    Process.repeatEval(Task.delay { Option(scala.Console.readLine()).getOrElse(throw Cause.Terminated(Cause.End)) })
+    Process.repeatEval(Task delay { Option(scala.Console.readLine()) }) pipe process1.stripNone
 
   /**
    * The standard output stream, as a `Sink`. This `Sink` does not

--- a/src/main/scala/scalaz/stream/wye.scala
+++ b/src/main/scala/scalaz/stream/wye.scala
@@ -836,9 +836,7 @@ object wye {
         }
       })(S)
 
-      repeatEval(Task.async[Seq[O]] { cb => a ! Get(cb) })
-      .flatMap(emitAll)
-      .onComplete(eval_(Task.async[Unit](cb => a ! DownDone(cb))))
+      repeatEval(Task.async[Seq[O]] { cb => a ! Get(cb) }) onHalt { _.asHalt } flatMap emitAll onComplete eval_(Task.async[Unit](cb => a ! DownDone(cb)))
     }
 }
 

--- a/src/test/scala/scalaz/stream/NioSpec.scala
+++ b/src/test/scala/scalaz/stream/NioSpec.scala
@@ -151,7 +151,7 @@ class NioSpec extends Properties("nio") {
       NioClient.echo(local, ByteVector(array1)).runLog.run.map(_.toSeq).flatten
     stop.set(true).run
 
-    (serverGot.get(30000) == Some(\/-(clientGot))) :| s"Server and client got same data" &&
+    (serverGot.get(30000) == Some(\/-(clientGot))) :| s"Server and client got same data (serverGot = ${serverGot.get(100)}; clientGot = $clientGot)" &&
       (clientGot == array1.toSeq.take(max)) :| "client got bytes before server closed connection"
 
   }

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -330,4 +330,12 @@ class ProcessSpec extends Properties("Process") {
 
     p0.sleepUntil(p2).toList === expected
   }
+
+  property("identity piping preserve eval termination semantics") = secure {
+    implicit val teq = Equal.equalA[Throwable]
+
+    val halt = eval(Task delay { throw Terminated(End) }).repeat ++ emit(())
+
+    ((halt pipe process1.id).runLog timed 3000 map { _.toList }).attempt.run === (halt.runLog timed 3000 map { _.toList }).attempt.run
+  }
 }


### PR DESCRIPTION
This is the compromise solution to #369.  `Terminated` is still here, and so is `asHalt`, but `eval` no longer magically swallows `Terminated` without warning anyone.  As a general rule, if you need `Terminated` (as some things do, due to the half-crippled nature of `Channel`), you need to add the `onHalt { _.asHalt }` bit explicitly.

The giant hanging chad in all of this is the fact that I had to change some code to explicitly contain this `onHalt` behavior even within scalaz-stream.  In general, this was confined to fairly low-level stuff (like the implementation of `wye`), but not always.  In particular, the `through` combinator got the `asHalt` treatment, since it is very common to implement effectful `Channel` termination via `Terminated`, and in fact under many circumstances there are no other options (e.g. pretty much every `Sink` ever).  We'll be able to remove this once we have a good solution for #351, but for now… bleh.