### PR TITLE
Maintain internal writer state machine upon initial signal value

### DIFF
--- a/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
+++ b/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
@@ -226,4 +226,21 @@ class AsyncSignalSpec extends Properties("async.signal") {
 
     (eval_(signal.set(1)) ++ signal.discrete.once ++ timer ++ signal.discrete.once).runLog.run ?= Vector(1,1)
   }
+
+  property("signalOf.init.value.cas") = secure {
+    val s = async.signalOf("init")
+
+    val resultsM = for {
+      _ <- s compareAndSet {
+        case Some("init") => Some("success")
+        case _ => Some("failed")
+      }
+
+      v <- s.get
+    } yield v
+
+    val results = resultsM.run
+
+    results == "success"
+  }
 }


### PR DESCRIPTION
This addresses #389.  The problem was that the `Writer1` inside of `Signal` would never set up its state machine with the initial value.  This PR fixes that by setting up the initial value via `feed1` rather than by emitting it over to `WriterTopic`.