### PR TITLE
skeleton for regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tags
 *#
 z_local.sbt
 .DS_Store
+tmp/

--- a/build.sbt
+++ b/build.sbt
@@ -75,3 +75,19 @@ initialCommands := "import scalaz.stream._"
 doctestWithDependencies := false
 
 doctestSettings
+
+// -------------------------------------------------------------------------------------------------
+// integration tests / regression testing
+// -------------------------------------------------------------------------------------------------
+
+configs(IntegrationTest)
+
+Defaults.itSettings
+
+libraryDependencies += "com.storm-enroute" %% "scalameter" % "0.6" % "it"
+
+logBuffered in IntegrationTest := false
+
+testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework")
+
+parallelExecution in IntegrationTest := false

--- a/src/it/scala/ProcessRegressionTest.scala
+++ b/src/it/scala/ProcessRegressionTest.scala
@@ -1,0 +1,22 @@
+package scalaz.stream
+
+import org.scalameter.api._
+
+import scalaz.concurrent.Task
+
+class ProcessRegressionTest extends PerformanceTest.OfflineRegressionReport {
+  val sizes = Gen.range("size")(10000, 50000, 20000)
+  val ones: Process[Task,Int] = Process.constant(1)
+  val streams = for (size <- sizes) yield (ones.take(size))
+
+  performance of "Process" in {
+    measure method "run" in {
+      using(streams) config (
+        exec.independentSamples -> 1
+      ) in { stream =>
+        val u = stream.run.run
+        u
+      }
+    }
+  }
+}


### PR DESCRIPTION
- adresses #399
- uses [scalameter regression testing][1]
- runs in sbt integration test target, i.e. `it:test`
- generates an offline html report in the tmp subdir of the main project
  dir, there is an index.html you can open to inspect the results, the
  regression history is also saved in that tmp subdir
- might need a few tweaks in terms of stability, confidence intervals, etc.
- I included just a simple dummy example to give you an idea of how it
  looks like, but adding new stuff to test should be straightforward
- I am not sure whether `Process.constant(1).take(n)` is the fastest way
  to create a reasonably sized Process

[1]: http://scalameter.github.io/home/gettingstarted/0.7/regressions/index.html