### PR TITLE
Add adapt function to Sink

### DIFF
--- a/src/main/scala/scalaz/stream/sink.scala
+++ b/src/main/scala/scalaz/stream/sink.scala
@@ -17,6 +17,10 @@ final class SinkSyntax[F[_], I](val self: Sink[F, I]) extends AnyVal {
   /** Converts `Sink` to `Channel`, that will perform the side effect and echo its input. */
   def toChannel(implicit F: Functor[F]): Channel[F, I, I] =
     self.map(f => (i: I) => f(i).as(i))
+
+  def adapt[B](f: B => I): Sink[F,B] = {
+    self.map(ff => ff.compose(f))
+  }
 }
 
 final class SinkTaskSyntax[I](val self: Sink[Task, I]) extends AnyVal {

--- a/src/test/scala/scalaz/stream/SinkSpec.scala
+++ b/src/test/scala/scalaz/stream/SinkSpec.scala
@@ -1,0 +1,19 @@
+package scalaz.stream
+
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+import scalaz.concurrent.Task
+import scalaz.stream.Process._
+
+class SinkSpec extends Properties("Sink") {
+  property("adapt") = forAll { list: List[Int] =>
+    val results = scala.collection.mutable.ListBuffer[String]()
+    val sink: Sink[Task, String] = Process.constant { a =>
+      Task.delay(results += a)
+    }
+    val process = Process.emitAll(list)
+    process.to(sink.adapt(_.toString)).run.run
+    results.toList == list.map(_.toString)
+  }
+}


### PR DESCRIPTION
I currently have this as an extension method in [Remotely](https://github.com/jedesah/remotely/blob/feature/streaming_take2/core/src/test/scala/StreamingSpec.scala#L48) but I saw a place in [http4s_demo](https://github.com/http4s/http4s_demo/blob/master/src/main/scala/org/http4s/example/Routes.scala#L43) where it could be used so I figured I would create a PR against scalaz-stream itself.