### PR TITLE
Add a constructor to Process for using iterators

### DIFF
--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -882,7 +882,7 @@ object Process extends ProcessInstances {
       else Process.halt
     }
 
-    Process.await(iteratorCreator)(iterator => go(iterator))
+    Process.await(iteratorCreator)(go)
   }
 
   /** Lazily produce the range `[start, stopExclusive)`. If you want to produce the sequence in one chunk, instead of lazily, use `emitAll(start until stopExclusive)`.  */

--- a/src/main/scala/scalaz/stream/Process.scala
+++ b/src/main/scala/scalaz/stream/Process.scala
@@ -872,8 +872,8 @@ object Process extends ProcessInstances {
     emit(start) ++ await(f(start))(iterateEval(_)(f))
 
   /**
-   * Lazily create an iterator to use as a source for a `Process`,
-   * which emits the values of the iterator, then halts.
+   * Create an iterator to use as a source for a `Process`,
+   * which lazily emits the values of the iterator, then halts.
    */
   def iterator[F[_], O](iteratorCreator: => F[Iterator[O]]): Process[F, O] = {
     //This design was based on unfold.

--- a/src/test/scala/scalaz/stream/ProcessSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessSpec.scala
@@ -92,6 +92,15 @@ class ProcessSpec extends Properties("Process") {
     Process.iterateEval(0)(i => Task.delay(i + 1)).take(100).runLog.run == List.iterate(0, 100)(_ + 1)
   }
 
+  property("iterator uses all its values and completes") = secure {
+    def iterator = Task(Iterator.range(0, 100, 1))
+    Process.iterator[Task, Int](iterator).runLog.run == Vector.range(0, 100, 1)
+  }
+
+  property("iterator completes immediately from an empty iterator") = secure {
+    Process.iterator[Task, Int](Task(Iterator.empty)).runLog.run.isEmpty
+  }
+
   property("kill executes cleanup") = secure {
     import TestUtil._
     val cleanup = new SyncVar[Int]


### PR DESCRIPTION
I find myself using an IteratorToProcess function quite often, so I think it should be in scalaz-stream. I've tried to make it as functional as possible, since iterators are mutable. I've done this by forcing the iterator to be recreated upon each evaluation of the process.