### PR TITLE
Add a constructor to Process for using iterators

### DIFF
--- a/src/main/scala/scalaz/stream/io.scala
+++ b/src/main/scala/scalaz/stream/io.scala
@@ -154,7 +154,7 @@ object io {
   /**
    * Create a Process from an iterator. The value behind the iterator should be
    * immutable and not rely on an external resource. If that is not the case, use
-   * `io.iterateR'`.
+   * `io.iterateR`.
    */
   def iterate[O](i: => Iterator[O]): Process[Task, O] = {
     await(Task.delay(i)) { iterator =>
@@ -174,13 +174,13 @@ object io {
    * @param req acquires the resource
    * @param release releases the resource
    * @param mkIterator creates the iterator from the resource
-   * @tparam R is the type of the resource
-   * @tparam O is the type of the values in the iterator
+   * @tparam R is the resource
+   * @tparam O is a value in the iterator
    * @return
    */
   def iterateR[R, O](req: => Task[R])(
-                    release: R => Task[Unit])(
-                    mkIterator: R => Iterator[O]): Process[Task, O] = {
+                     release: R => Task[Unit])(
+                     mkIterator: R => Iterator[O]): Process[Task, O] = {
     bracket[Task, R, O](req)(r => Process.eval_(release(r)))(r => iterate(mkIterator(r)) )
   }
 

--- a/src/test/scala/scalaz/stream/IteratorSpec.scala
+++ b/src/test/scala/scalaz/stream/IteratorSpec.scala
@@ -11,15 +11,16 @@ import scalaz.concurrent.Task
 class IteratorSpec extends Properties("iterators") {
 
   property("io.iterate completes immediately from an empty iterator") = secure {
-    io.iterate[Int](Iterator.empty).runLog.run.isEmpty
+    io.iterator[Int](Task.now(Iterator.empty)).runLog.run.isEmpty
   }
 
   property("io.iterate uses all its values and completes") = forAll { (ints: Vector[Int]) =>
-    io.iterate[Int](ints.toIterator).runLog.run == ints
+    io.iterator[Int](Task(ints.toIterator)).runLog.run == ints
   }
 
   property("io.iterate is re-usable") = forAll { (ints: Vector[Int]) =>
-    io.iterate(ints.toIterator).runLog.run == io.iterate(ints.toIterator).runLog.run
+    val intsIterator = Task(ints.toIterator)
+    io.iterator(intsIterator).runLog.run == io.iterator(intsIterator).runLog.run
   }
 
   case class IteratorResource[T](items: T*) {
@@ -48,7 +49,7 @@ class IteratorSpec extends Properties("iterators") {
 
 
 
-    io.iterateR(acquire)(release)(_.iterator).run.run
+    io.iteratorR(acquire)(release)(r => Task(r.iterator)).run.run
 
     resource.exists(_.isReleased)
   }


### PR DESCRIPTION
I find myself using my own IteratorToProcess method quite often, so I think probably an Process constructor from iterators belongs in scalaz-stream. It can be dangerous since iterators aren't re-usable, but I hope the warning I added in the documentation is enough to put people on the right path.