### PR TITLE
Update scalacheck to 1.12.4, evalulate properties lazily.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-concurrent" % "7.1.2",
   "org.scodec" %% "scodec-bits" % "1.0.6",
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.2" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.12.2" % "test"
+  "org.scalacheck" %% "scalacheck" % "1.12.4" % "test"
 )
 
 seq(bintraySettings:_*)

--- a/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
+++ b/src/test/scala/scalaz/stream/AsyncSignalSpec.scala
@@ -166,13 +166,13 @@ class AsyncSignalSpec extends Properties("async.signal") {
 
 
   //tests a signal from discrete process
-  property("from.discrete") = secure {
+  property("from.discrete") = protect {
     val sig = async.toSignal[Int](Process(1,2,3,4).toSource)
     sig.discrete.take(4).runLog.run == Vector(1,2,3,4)
   }
 
   //tests that signal terminates when discrete process terminates
-  property("from.discrete.terminates") = secure {
+  property("from.discrete.terminates") = protect {
     val sleeper = Process.eval_{Task.delay(Thread.sleep(1000))}
     val sig = async.toSignal[Int](sleeper ++ Process(1,2,3,4).toSource)
     val initial = sig.discrete.runLog.run
@@ -181,7 +181,7 @@ class AsyncSignalSpec extends Properties("async.signal") {
   }
 
   //tests that signal terminates with failure when discrete process terminates with failure
-  property("from.discrete.fail") = secure {
+  property("from.discrete.fail") = protect {
     val sleeper = Process.eval_{Task.delay(Thread.sleep(1000))}
     val sig = async.toSignal[Int](sleeper ++ Process(1,2,3,4).toSource ++ Process.fail(Bwahahaa))
     sig.discrete.runLog.attemptRun == -\/(Bwahahaa)
@@ -189,13 +189,13 @@ class AsyncSignalSpec extends Properties("async.signal") {
 
   // tests that signal terminates with failure when discrete
   // process terminates with failure even when haltOnSource is set to false
-  property("from.discrete.fail.always") = secure {
+  property("from.discrete.fail.always") = protect {
     val sleeper = Process.eval_{Task.delay(Thread.sleep(1000))}
     val sig = async.toSignal[Int](sleeper ++ Process(1,2,3,4).toSource ++ Process.fail(Bwahahaa))
     sig.discrete.runLog.attemptRun == -\/(Bwahahaa)
   }
 
-  property("continuous") = secure {
+  property("continuous") = protect {
     val sig = async.signalUnset[Int]
     time.awakeEvery(100.millis)
       .zip(Process.range(1, 13))
@@ -220,14 +220,14 @@ class AsyncSignalSpec extends Properties("async.signal") {
   }
 
 
-  property("signalOf.init.value") = secure {
+  property("signalOf.init.value") = protect {
     val timer = time.sleep(1.second)
     val signal = async.signalOf(0)
 
     (eval_(signal.set(1)) ++ signal.discrete.once ++ timer ++ signal.discrete.once).runLog.run ?= Vector(1,1)
   }
 
-  property("signalOf.init.value.cas") = secure {
+  property("signalOf.init.value.cas") = protect {
     val s = async.signalOf("init")
 
     val resultsM = for {

--- a/src/test/scala/scalaz/stream/AsyncTopicSpec.scala
+++ b/src/test/scala/scalaz/stream/AsyncTopicSpec.scala
@@ -164,7 +164,7 @@ class AsyncTopicSpec extends Properties("topic") {
       }
   }
 
-  property("writer.state.startWith.down") = secure {
+  property("writer.state.startWith.down") = protect {
     val topic = async.writerTopic(emit(-\/(0L)) ++ WriterHelper.w)()
     val subscriber = topic.subscribe.take(1).runLog.run
     topic.close.run
@@ -173,14 +173,14 @@ class AsyncTopicSpec extends Properties("topic") {
   }
 
   //tests a topic from discrete process
-  property("from.discrete") = secure {
+  property("from.discrete") = protect {
     val topic = async.writerTopic[Long,String,Int](WriterHelper.w)(Process(1,2,3,4).map(i=>"*"*i).toSource)
     val r = topic.subscribe.take(8).runLog.run
     r == Vector(-\/(1),\/-(1) ,-\/(3) ,\/-(2)  ,-\/(6) ,\/-(3)  ,-\/(10) ,\/-(4))
   }
 
   //tests a topic from discrete process
-  property("from.discrete") = secure {
+  property("from.discrete") = protect {
     val topic = async.writerTopic[Long,String,Int](WriterHelper.w onComplete (tell(0L) ++ emitO(0)))(Process(1,2,3,4).map(i=>"*"*i), haltOnSource = true)
     val r = topic.subscribe.take(10).runLog.run
     r == Vector(-\/(1),\/-(1) ,-\/(3) ,\/-(2)  ,-\/(6) ,\/-(3)  ,-\/(10) ,\/-(4), -\/(0), \/-(0))

--- a/src/test/scala/scalaz/stream/CauseSpec.scala
+++ b/src/test/scala/scalaz/stream/CauseSpec.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.ScheduledExecutorService
 class CauseSpec extends Properties("cause") {
   implicit val S: ScheduledExecutorService = DefaultScheduler
 
-  property("suspend") = secure {
+  property("suspend") = protect {
     val source = Process(1, 2, 3).toSource
     val halted: Process[Task, Int] = halt
     val failed: Process[Task, Int] = fail(Bwahahaa)
@@ -40,7 +40,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("pipe.terminated.p1") = secure {
+  property("pipe.terminated.p1") = protect {
     val source = Process(1) ++ Process(2) ++ Process(3).toSource
     var upReason: Option[Cause] = None
     var downReason: Option[Cause] = None
@@ -56,7 +56,7 @@ class CauseSpec extends Properties("cause") {
     .&&(downReason == Some(End))
   }
 
-  property("pipe.terminated.p1.flatMap.repeatEval") = secure {
+  property("pipe.terminated.p1.flatMap.repeatEval") = protect {
     val source = repeatEval(Task.now(1))
     var upReason: Option[Cause] = None
     var downReason: Option[Cause] = None
@@ -73,7 +73,7 @@ class CauseSpec extends Properties("cause") {
     .&&(downReason == Some(End))
   }
 
-  property("pipe.terminated.p1.with.upstream") = secure {
+  property("pipe.terminated.p1.with.upstream") = protect {
     val source = emitAll(Seq(1,2,3)).toSource
     var upReason: Option[Cause] = None
     var downReason: Option[Cause] = None
@@ -91,7 +91,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("pipe.terminated.upstream") = secure {
+  property("pipe.terminated.upstream") = protect {
     val source = emitAll(Seq(1,2,3)).toSource
     var id1Reason: Option[Cause] = None
     var downReason: Option[Cause] = None
@@ -107,7 +107,7 @@ class CauseSpec extends Properties("cause") {
     .&&(downReason == Some(End))
   }
 
-  property("pipe.killed.upstream") = secure {
+  property("pipe.killed.upstream") = protect {
     val source = (Process(1) ++ Process(2).kill).toSource
     var id1Reason: Option[Cause] = None
     var downReason: Option[Cause] = None
@@ -124,7 +124,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("tee.terminated.tee") = secure {
+  property("tee.terminated.tee") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -145,7 +145,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("tee.terminated.tee.onLeft") = secure {
+  property("tee.terminated.tee.onLeft") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -166,7 +166,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("tee.terminated.tee.onRight") = secure {
+  property("tee.terminated.tee.onRight") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -187,7 +187,7 @@ class CauseSpec extends Properties("cause") {
     .&& (processReason == Some(End))
   }
 
-  property("tee.terminated.left.onLeft") = secure {
+  property("tee.terminated.left.onLeft") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -211,7 +211,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("tee.terminated.right.onRight") = secure {
+  property("tee.terminated.right.onRight") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -234,7 +234,7 @@ class CauseSpec extends Properties("cause") {
     .&& (teeReason == Some(Kill))
   }
 
-  property("tee.terminated.leftAndRight.onLeftAndRight") = secure {
+  property("tee.terminated.leftAndRight.onLeftAndRight") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -257,7 +257,7 @@ class CauseSpec extends Properties("cause") {
     .&& (teeReason == Some(Kill)) //killed due left input exhausted awaiting left branch
   }
 
-  property("tee.terminated.leftAndRight.onRightAndLeft") = secure {
+  property("tee.terminated.leftAndRight.onRightAndLeft") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -280,7 +280,7 @@ class CauseSpec extends Properties("cause") {
     .&& (teeReason == Some(Kill)) //killed due right input exhausted awaiting right branch
   }
 
-  property("tee.terminated.downstream") = secure {
+  property("tee.terminated.downstream") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -304,7 +304,7 @@ class CauseSpec extends Properties("cause") {
     .&& (teeReason == Some(Kill)) //Tee is killed because downstream terminated
   }
 
-  property("tee.kill.left") = secure {
+  property("tee.kill.left") = protect {
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
     var teeReason: Option[Cause] = None
@@ -328,7 +328,7 @@ class CauseSpec extends Properties("cause") {
     .&& (beforePipeReason == Some(Kill))
   }
 
-  property("tee.kill.right") = secure {
+  property("tee.kill.right") = protect {
     var leftReason: Option[Cause] = None
     var processReason: Option[Cause] = None
     var teeReason: Option[Cause] = None
@@ -354,7 +354,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("tee.pipe.kill") = secure {
+  property("tee.pipe.kill") = protect {
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
     var teeReason: Option[Cause] = None
@@ -383,7 +383,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("wye.terminated.wye") = secure {
+  property("wye.terminated.wye") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -404,7 +404,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("wye.terminated.wye.onLeft") = secure {
+  property("wye.terminated.wye.onLeft") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -426,7 +426,7 @@ class CauseSpec extends Properties("cause") {
     .&& (processReason == Some(End))
   }
 
-  property("wye.terminated.wye.onRight") = secure {
+  property("wye.terminated.wye.onRight") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
@@ -449,7 +449,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("wye.kill.merge.onLeft") = secure {
+  property("wye.kill.merge.onLeft") = protect {
     var rightReason: Option[Cause] = None
     var processReason: Option[Cause] = None
     var wyeReason: Option[Cause] = None
@@ -470,7 +470,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("wye.kill.merge.onRight") = secure {
+  property("wye.kill.merge.onRight") = protect {
     var leftReason: Option[Cause] = None
     var processReason: Option[Cause] = None
     var wyeReason: Option[Cause] = None
@@ -490,7 +490,7 @@ class CauseSpec extends Properties("cause") {
     .&& (processReason == Some(Kill))
   }
 
-  property("wye.kill.downstream") = secure {
+  property("wye.kill.downstream") = protect {
     var leftReason: Option[Cause] = None
     var rightReason: Option[Cause] = None
     var pipeReason: Option[Cause] = None
@@ -517,7 +517,7 @@ class CauseSpec extends Properties("cause") {
   }
 
 
-  property("pipe, tee, wye does not swallow Kill from outside") = secure {
+  property("pipe, tee, wye does not swallow Kill from outside") = protect {
     val p1 = await1 onHalt { x => Process(1, 2).causedBy(x) }
 
     // Read from the left then from the right.

--- a/src/test/scala/scalaz/stream/CompressSpec.scala
+++ b/src/test/scala/scalaz/stream/CompressSpec.scala
@@ -17,11 +17,11 @@ class CompressSpec extends Properties("compress") {
   def foldBytes(bytes: List[ByteVector]): ByteVector =
     bytes.fold(ByteVector.empty)(_ ++ _)
 
-  property("deflate.empty input") = secure {
+  property("deflate.empty input") = protect {
     Process[ByteVector]().pipe(deflate()).toList.isEmpty
   }
 
-  property("inflate.empty input") = secure {
+  property("inflate.empty input") = protect {
     Process[ByteVector]().pipe(inflate()).toList.isEmpty
   }
 
@@ -53,7 +53,7 @@ class CompressSpec extends Properties("compress") {
     foldBytes(input) == foldBytes(inflated)
   }
 
-  property("deflate.compresses input") = secure {
+  property("deflate.compresses input") = protect {
     val uncompressed = getBytes(
       """"
         |"A type system is a tractable syntactic method for proving the absence
@@ -65,7 +65,7 @@ class CompressSpec extends Properties("compress") {
     compressed.length < uncompressed.length
   }
 
-  property("inflate.uncompressed input") = secure {
+  property("inflate.uncompressed input") = protect {
     emit(getBytes("Hello")).pipe(inflate()).attempt().toList match {
       case List(-\/(ex: java.util.zip.DataFormatException)) => true
       case _ => false

--- a/src/test/scala/scalaz/stream/ExchangeSpec.scala
+++ b/src/test/scala/scalaz/stream/ExchangeSpec.scala
@@ -12,39 +12,39 @@ class ExchangeSpec extends Properties("Exchange") {
 
   implicit val scheduler =  scalaz.stream.DefaultScheduler
 
-  property("loopBack") = secure {
+  property("loopBack") = protect {
     val xs = 1 until 10
     val l = Exchange.loopBack[String, Int](process1.lift[Int, String](_.toString))
     l.flatMap(_.run(emitAll(xs))).take(xs.size).runLog.run.toSeq == xs.map(_.toString)
   }
 
-  property("emitHead") = secure {
+  property("emitHead") = protect {
     val xs = 1 until 10
     val l = Exchange.loopBack[Int, Int](emitAll(xs) ++ process1.id)
     l.flatMap(_.run(emitAll(xs))).take(xs.size + xs.size / 2).runLog.run.toSeq == xs ++ xs.take(xs.size / 2)
   }
 
-  property("loopBack.terminate.process1") = secure {
+  property("loopBack.terminate.process1") = protect {
     val xs = 1 until 10
     val l = Exchange.loopBack[Int, Int](process1.take(5))
     l.flatMap(_.run(emitAll(xs))).runLog.run.toSeq == xs.take(5)
   }
 
 
-  property("mapO") = secure {
+  property("mapO") = protect {
     val xs = 1 until 10
     val l = Exchange.loopBack[Int, Int](process1.id).map(_.mapO(_.toString))
     l.flatMap(_.run(emitAll(xs))).take(xs.size).runLog.run == xs.map(_.toString)
   }
 
-  property("mapW") = secure {
+  property("mapW") = protect {
     val xs = 1 until 10
     val l = Exchange.loopBack[Int, Int](process1.id).map(_.mapW[String](_.toInt))
     l.flatMap(_.run(emitAll(xs.map(_.toString)))).take(xs.size).runLog.run == xs
   }
 
 
-  property("pipeBoth") = secure {
+  property("pipeBoth") = protect {
     val xs = 1 until 10
     val l =
       Exchange.loopBack[Int, Int](process1.id)
@@ -57,25 +57,25 @@ class ExchangeSpec extends Properties("Exchange") {
   }
 
 
-  property("through") = secure {
+  property("through") = protect {
     val xs = 1 until 10
     val ch: Channel[Task, Int, Process[Task, (Int, Int)]] = constant((i: Int) => Task.now(emitAll(xs).toSource.map((i, _))))
     val l = Exchange.loopBack[Int, Int](process1.id).map(_.through(ch))
     l.flatMap(_.run(emitAll(xs))).take(xs.size * xs.size).runLog.run == xs.map(i => xs.map(i2 => (i, i2))).flatten
   }
 
-  property("run.terminate.on.read") = secure {
+  property("run.terminate.on.read") = protect {
     val ex = Exchange[Int,Int](Process.range(1,10),Process.constant(i => Task.now(())))
     ex.run(time.sleep(1 minute)).runLog.timed(3000).run == (1 until 10).toVector
   }
 
 
-  property("run.terminate.on.write") = secure {
+  property("run.terminate.on.write") = protect {
     val ex = Exchange[Int,Int](time.sleep(1 minute),Process.constant(i => Task.now(())))
     ex.run(Process.range(1,10), Request.R).runLog.timed(3000).run == Vector()
   }
 
-  property("run.terminate.on.read.or.write") = secure {
+  property("run.terminate.on.read.or.write") = protect {
     val exL = Exchange[Int,Int](Process.range(1,10),Process.constant(i => Task.now(())))
     val exR = Exchange[Int,Int](time.sleep(1 minute),Process.constant(i => Task.now(())))
     ("left side terminated" |: exL.run(time.sleep(1 minute), Request.Both).runLog.timed(3000).run == (1 until 10).toVector) &&

--- a/src/test/scala/scalaz/stream/HashSpec.scala
+++ b/src/test/scala/scalaz/stream/HashSpec.scala
@@ -33,7 +33,7 @@ class HashSpec extends Properties("hash") {
     ("sha512" |: checkDigest(sha512, "SHA-512", s))
   }
 
-  property("empty input") = secure {
+  property("empty input") = protect {
     Process[ByteVector]().pipe(md2).toList.isEmpty
   }
 
@@ -48,7 +48,7 @@ class HashSpec extends Properties("hash") {
     }
   }
 
-  property("thread-safety") = secure {
+  property("thread-safety") = protect {
     val proc = range(1,100).toSource
       .map(i => ByteVector.view(i.toString.getBytes))
       .pipe(sha512).map(Tag.unwrap(_).toSeq)

--- a/src/test/scala/scalaz/stream/LinesSpec.scala
+++ b/src/test/scala/scalaz/stream/LinesSpec.scala
@@ -23,11 +23,11 @@ class LinesSpec extends Properties("text") {
       emit(s).pipe(lines()).toList == source
   }
 
-  property("lines()") = secure {
+  property("lines()") = protect {
     samples.forall(checkLine)
   }
 
-  property("lines(n) should fail for lines with length greater than n") = secure {
+  property("lines(n) should fail for lines with length greater than n") = protect {
     val error = classOf[LengthExceeded]
 
     emit("foo\nbar").pipe(lines(3)).toList == List("foo", "bar")    &&   // OK input

--- a/src/test/scala/scalaz/stream/NioFilesSpec.scala
+++ b/src/test/scala/scalaz/stream/NioFilesSpec.scala
@@ -27,21 +27,21 @@ class NioFilesSpec extends Properties("niofiles") {
     finally is.close()
   }
 
-  property("chunkR can read a file") = secure {
+  property("chunkR can read a file") = protect {
     val bytes = Process.constant(1024).toSource
       .through(chunkR(filename)).runLog.run.reduce(_ ++ _)
 
     bytes == ByteVector.view(getfile(filename))
   }
 
-  property("linesR can read a file") = secure {
+  property("linesR can read a file") = protect {
     val iostrs = io.linesR(filename)(Codec.UTF8).runLog.run.toList
     val niostrs = linesR(filename)(Codec.UTF8).runLog.run.toList
 
     iostrs == niostrs
   }
 
-  property("chunkW can write a file") = secure {
+  property("chunkW can write a file") = protect {
 
     val tmpname = "testdata/tempdata.tmp"
     Process.constant(1).toSource

--- a/src/test/scala/scalaz/stream/NioSpec.scala
+++ b/src/test/scala/scalaz/stream/NioSpec.scala
@@ -103,14 +103,14 @@ class NioSpec extends Properties("nio") {
   implicit val AG = nio.DefaultAsynchronousChannelGroup
   implicit val S: ScheduledExecutorService = DefaultScheduler
 
-  //  property("loop-server") = secure {
+  //  property("loop-server") = protect {
   //    NioServer.limit(local,3).run.run
   //    false
   //  }
 
 
   //simple connect to server send size of bytes and got back what was sent
-  property("connect-echo-done") = secure {
+  property("connect-echo-done") = protect {
     val local = localAddress(11100)
     val size: Int = 500000
     val array1 = Array.fill[Byte](size)(1)
@@ -134,7 +134,7 @@ class NioSpec extends Properties("nio") {
   }
 
 
-  property("connect-server-terminates") = secure {
+  property("connect-server-terminates") = protect {
     val local = localAddress(11101)
     val max: Int = 50
     val size: Int = 5000
@@ -162,7 +162,7 @@ class NioSpec extends Properties("nio") {
   // connects large number of client to server, each sending up to `size` data and server replying them back
   // at the end server shall have collected all data from all clients and all clients shall get echoed back
   // what they have sent to server
-  property("connect-server-many") = secure {
+  property("connect-server-many") = protect {
     val local = localAddress(11102)
     val count: Int = 100
     val size: Int = 10000

--- a/src/test/scala/scalaz/stream/PrintSpec.scala
+++ b/src/test/scala/scalaz/stream/PrintSpec.scala
@@ -3,7 +3,7 @@ package scalaz.stream
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.util.concurrent.ScheduledExecutorService
 
-import org.scalacheck.Prop.secure
+import org.scalacheck.Prop.protect
 import org.scalacheck.Properties
 
 import scalaz.concurrent.Task
@@ -11,7 +11,7 @@ import scalaz.concurrent.Task
 class PrintSpec extends Properties("io.print") {
   implicit val S: ScheduledExecutorService = DefaultScheduler
 
-  property("print terminates on process close") = secure {
+  property("print terminates on process close") = protect {
     terminates { out =>
       Process
         .constant("word").toSource.repeat
@@ -19,7 +19,7 @@ class PrintSpec extends Properties("io.print") {
     }
   }
 
-  property("printLines terminates on process close") = secure {
+  property("printLines terminates on process close") = protect {
     terminates { out =>
       Process
         .constant("word").toSource.repeat
@@ -27,7 +27,7 @@ class PrintSpec extends Properties("io.print") {
     }
   }
 
-  property("print outputs values and terminates") = secure {
+  property("print outputs values and terminates") = protect {
     val baos = new ByteArrayOutputStream
     val out = new PrintStream(baos)
 

--- a/src/test/scala/scalaz/stream/Process1Spec.scala
+++ b/src/test/scala/scalaz/stream/Process1Spec.scala
@@ -128,7 +128,7 @@ class Process1Spec extends Properties("Process1") {
     }
   }
 
-  property("inner-cleanup") = secure {
+  property("inner-cleanup") = protect {
     val p = Process.range(0,20).toSource
     var called  = false
     ((p onComplete suspend{ called = true ; halt})
@@ -136,21 +136,21 @@ class Process1Spec extends Properties("Process1") {
       .&&("cleanup was called" |: called)
   }
 
-  property("chunk") = secure {
+  property("chunk") = protect {
     Process(0, 1, 2, 3, 4).chunk(2).toList === List(Vector(0, 1), Vector(2, 3), Vector(4))
   }
 
-  property("chunkBy") = secure {
+  property("chunkBy") = protect {
     emitAll("foo bar baz").chunkBy(_ != ' ').toList.map(_.mkString) === List("foo ", "bar ", "baz")
   }
 
-  property("chunkBy2") = secure {
+  property("chunkBy2") = protect {
     val p = Process(3, 5, 4, 3, 1, 2, 6)
     p.chunkBy2(_ < _).toList === List(Vector(3, 5), Vector(4), Vector(3), Vector(1, 2, 6)) &&
     p.chunkBy2(_ > _).toList === List(Vector(3), Vector(5, 4, 3, 1), Vector(2), Vector(6))
   }
 
-  property("distinctConsecutive") = secure {
+  property("distinctConsecutive") = protect {
     Process[Int]().distinctConsecutive.toList.isEmpty &&
     Process(1, 2, 3, 4).distinctConsecutive.toList === List(1, 2, 3, 4) &&
     Process(1, 1, 2, 2, 3, 3, 4, 3).distinctConsecutive.toList === List(1, 2, 3, 4, 3) &&
@@ -158,7 +158,7 @@ class Process1Spec extends Properties("Process1") {
       List("1", "33", "5", "66")
   }
 
-  property("drainLeading") = secure {
+  property("drainLeading") = protect {
     val p = emit(1) ++ await1[Int]
     Process().pipe(p).toList === List(1) &&
     Process().pipe(drainLeading(p)).toList.isEmpty &&
@@ -177,7 +177,7 @@ class Process1Spec extends Properties("Process1") {
     results.toList === (xs.scan(init)(f) drop 1)
   }
 
-  property("repartition") = secure {
+  property("repartition") = protect {
     Process("Lore", "m ip", "sum dolo", "r sit amet").repartition(_.split(" ")).toList ===
       List("Lorem", "ipsum", "dolor", "sit", "amet") &&
     Process("hel", "l", "o Wor", "ld").repartition(_.grouped(2).toVector).toList ===
@@ -188,7 +188,7 @@ class Process1Spec extends Properties("Process1") {
     Process("hello").repartition(_ => Vector()).toList.isEmpty
   }
 
-  property("repartition2") = secure {
+  property("repartition2") = protect {
     Process("he", "ll", "o").repartition2(s => (Some(s), None)).toList ===
       List("he", "ll", "o") &&
     Process("he", "ll", "o").repartition2(s => (None, Some(s))).toList ===
@@ -198,17 +198,17 @@ class Process1Spec extends Properties("Process1") {
     Process("he", "ll", "o").repartition2(_ => (None, None)).toList.isEmpty
   }
 
-  property("splitOn") = secure {
+  property("splitOn") = protect {
     Process(0, 1, 2, 3, 4).splitOn(2).toList === List(Vector(0, 1), Vector(3, 4)) &&
     Process(2, 0, 1, 2).splitOn(2).toList === List(Vector(), Vector(0, 1), Vector()) &&
     Process(2, 2).splitOn(2).toList === List(Vector(), Vector(), Vector())
   }
 
-  property("stripNone") = secure {
+  property("stripNone") = protect {
     Process(None, Some(1), None, Some(2), None).pipe(stripNone).toList === List(1, 2)
   }
 
-  property("terminated") = secure {
+  property("terminated") = protect {
     Process[Int]().terminated.toList === List(None) &&
     Process(1, 2, 3).terminated.toList === List(Some(1), Some(2), Some(3), None)
   }
@@ -217,19 +217,19 @@ class Process1Spec extends Properties("Process1") {
     pi.pipe(unchunk).toList === pi.toList.flatten
   }
 
-  property("zipWithPrevious") = secure {
+  property("zipWithPrevious") = protect {
     range(0, 0).zipWithPrevious.toList.isEmpty &&
     range(0, 1).zipWithPrevious.toList === List((None, 0)) &&
     range(0, 3).zipWithPrevious.toList === List((None, 0), (Some(0), 1), (Some(1), 2))
   }
 
-  property("zipWithNext") = secure {
+  property("zipWithNext") = protect {
     range(0, 0).zipWithNext.toList.isEmpty &&
     range(0, 1).zipWithNext.toList === List((0, None)) &&
     range(0, 3).zipWithNext.toList === List((0, Some(1)), (1, Some(2)), (2, None))
   }
 
-  property("zipWithPreviousAndNext") = secure {
+  property("zipWithPreviousAndNext") = protect {
     range(0, 0).zipWithPreviousAndNext.toList.isEmpty &&
     range(0, 1).zipWithPreviousAndNext.toList === List((None, 0, None)) &&
     range(0, 3).zipWithPreviousAndNext.toList === List((None, 0, Some(1)), (Some(0), 1, Some(2)), (Some(1), 2, None))

--- a/src/test/scala/scalaz/stream/ProcessPerformanceSpec.scala
+++ b/src/test/scala/scalaz/stream/ProcessPerformanceSpec.scala
@@ -94,10 +94,10 @@ class ProcessPerformanceSpec extends Properties("Process-performance") {
 
 
   // these properties won't complete, in case of quadratic complexity
-  property("append") = secure { associationCheck(append.left, append.right) }
-  property("flatMap") = secure { associationCheck(flatMap.left1, flatMap.right1) }
-  property("flatMap-append") = secure { checkOne(flatMap.leftAppend, distribution = Seq(14, 15, 16, 17, 18, 19, 20, 21)) }
-  property("flatMap-nested") = secure { checkOne(flatMap.rightNested) }
-  property("worstCase") = secure { checkOne(worstCase.churned, distribution = (Seq(1,2,4,8,16,32,64,128,256,512,1024,2048))) }
+  property("append") = protect { associationCheck(append.left, append.right) }
+  property("flatMap") = protect { associationCheck(flatMap.left1, flatMap.right1) }
+  property("flatMap-append") = protect { checkOne(flatMap.leftAppend, distribution = Seq(14, 15, 16, 17, 18, 19, 20, 21)) }
+  property("flatMap-nested") = protect { checkOne(flatMap.rightNested) }
+  property("worstCase") = protect { checkOne(worstCase.churned, distribution = (Seq(1,2,4,8,16,32,64,128,256,512,1024,2048))) }
 
 }

--- a/src/test/scala/scalaz/stream/QueueSpec.scala
+++ b/src/test/scala/scalaz/stream/QueueSpec.scala
@@ -102,7 +102,7 @@ class QueueSpec extends Properties("queue") {
 
 
 
-  property("closes-pub-sub") = secure {
+  property("closes-pub-sub") = protect {
     val l: List[Int] = List(1, 2, 3)
     val q = async.unboundedQueue[Int]
     val t1 = Task {
@@ -134,7 +134,7 @@ class QueueSpec extends Properties("queue") {
 
   // tests situation where killed process may `swallow` item in queue
   // from the process that is running
-  property("queue-swallow-killed") = secure {
+  property("queue-swallow-killed") = protect {
     val q = async.unboundedQueue[Int]
     val sleeper = time.sleep(1 second)
     val signalKill = Process(false).toSource ++ sleeper ++ Process(true)
@@ -162,7 +162,7 @@ class QueueSpec extends Properties("queue") {
       (s"All values were collected, all: ${collected.get(0)}, l: $l " |: collected.get.getOrElse(Nil).flatten == l)
   }
 
-  property("dequeue-batch.chunked") = secure {
+  property("dequeue-batch.chunked") = protect {
     import Function.const
 
     val q = async.unboundedQueue[Int]
@@ -182,7 +182,7 @@ class QueueSpec extends Properties("queue") {
       ((collected.get getOrElse Nil) == Seq(Seq(1), Seq(1, 1), Seq(2, 2, 2, 2), Seq(4, 4, 4, 4, 4, 4, 4, 4))) :| s"saw ${collected.get getOrElse Nil}"
   }
 
-  property("dequeue-batch.chunked-limited") = secure {
+  property("dequeue-batch.chunked-limited") = protect {
     import Function.const
 
     val q = async.unboundedQueue[Int]
@@ -228,7 +228,7 @@ class QueueSpec extends Properties("queue") {
     }
   }
 
-  property("dequeue.take-1-repeatedly") = secure {
+  property("dequeue.take-1-repeatedly") = protect {
     val q = async.unboundedQueue[Int]
     q.enqueueAll(List(1, 2, 3)).run
 

--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -33,7 +33,7 @@ class ResourceSafetySpec extends Properties("resource-safety") {
   def die = throw bwah
 
 
-  property("cleanups") = secure {
+  property("cleanups") = protect {
     import Process._
     val thrown = new ConcurrentLinkedQueue[Cause]() // non-det tests need thread-safety
     def cleanup(cause:Cause) =  { thrown.add(cause) ; Halt(cause) }
@@ -85,7 +85,7 @@ class ResourceSafetySpec extends Properties("resource-safety") {
     result.reduce(_ && _)
   }
 
-  property("repeated kill") = secure {
+  property("repeated kill") = protect {
     import TestUtil._
     var cleaned = false
     (emit(1) onComplete eval_(Task.delay(cleaned = true))).kill.kill.kill.expectedCause(_ == Kill).run.run

--- a/src/test/scala/scalaz/stream/TimeSpec.scala
+++ b/src/test/scala/scalaz/stream/TimeSpec.scala
@@ -13,11 +13,11 @@ class TimeSpec extends Properties("time") {
   implicit val S = Strategy.DefaultStrategy
   implicit val scheduler = scalaz.stream.DefaultScheduler
 
-  property("awakeEvery") = secure {
+  property("awakeEvery") = protect {
     time.awakeEvery(100 millis).map(_.toMillis/100).take(5).runLog.run == Vector(1,2,3,4,5)
   }
 
-  property("duration") = secure {
+  property("duration") = protect {
     val firstValueDiscrepancy = time.duration.once.runLast
     val reasonableErrorInMillis = 200
     val reasonableErrorInNanos = reasonableErrorInMillis * 1000000

--- a/src/test/scala/scalaz/stream/ToInputStreamSpec.scala
+++ b/src/test/scala/scalaz/stream/ToInputStreamSpec.scala
@@ -1,7 +1,7 @@
 package scalaz.stream
 
 import org.scalacheck._
-import Prop.{ BooleanOperators, forAll, secure, throws }
+import Prop.{ BooleanOperators, forAll, protect, throws }
 
 import scodec.bits.ByteVector
 
@@ -67,7 +67,7 @@ class ToInputStreamSpec extends Properties("toInputStream") {
     List(buffer: _*) == bytes.flatten
   }
 
-  property("handles one append within an await") = secure {
+  property("handles one append within an await") = protect {
     val bytes: List[List[List[Byte]]] = List(List(), List(List(127)))
     val length = bytes map { _ map { _.length } sum } sum
 
@@ -102,7 +102,7 @@ class ToInputStreamSpec extends Properties("toInputStream") {
     List(buffer: _*) == (bytes flatMap { _.flatten })
   }
 
-  property("invokes finalizers when terminated early") = secure {
+  property("invokes finalizers when terminated early") = protect {
     import Process._
 
     var flag = false
@@ -119,7 +119,7 @@ class ToInputStreamSpec extends Properties("toInputStream") {
       (read == 42) :| "read value"
   }
 
-  property("invokes writer emitters when terminated early") = secure {
+  property("invokes writer emitters when terminated early") = protect {
     import Process._
 
     var flag = false
@@ -138,20 +138,20 @@ class ToInputStreamSpec extends Properties("toInputStream") {
       (read == 42) :| "read value"
   }
 
-  property("safely read byte 255 as an Int") = secure {
+  property("safely read byte 255 as an Int") = protect {
     val p = Process emit Array[Byte](-1)
     val is = io.toInputStream(p map { ByteVector view _ })
 
     is.read() == 255
   }
 
-  property("handles exceptions") = secure {
+  property("handles exceptions") = protect {
     val p: Process[Task, ByteVector] = Process eval Task.fail(new Exception())
     val is = io.toInputStream(p)
     throws(classOf[IOException])(is.read())
   }
 
-  property("after close read should return -1") = secure {
+  property("after close read should return -1") = protect {
     val p = Process emitAll Seq(Array[Byte](1, 2), Array[Byte](3, 4))
     val is = io.toInputStream(p map { ByteVector view _ })
     is.read()

--- a/src/test/scala/scalaz/stream/UnsafeChunkRSpec.scala
+++ b/src/test/scala/scalaz/stream/UnsafeChunkRSpec.scala
@@ -2,14 +2,14 @@ package scalaz.stream
 
 import java.io.ByteArrayInputStream
 
-import org.scalacheck.Prop.{ forAll, propBoolean, secure }
+import org.scalacheck.Prop.{ forAll, propBoolean, protect }
 import org.scalacheck.Properties
 
 import scalaz.concurrent.Task
 import scalaz.stream.Process.ProcessSyntax
 
 class UnsafeChunkRSpec extends Properties("io.unsafeChunkR") {
-  property("reuses buffer") = secure {
+  property("reuses buffer") = protect {
     forAll { str: String =>
       val sink: Sink[Task, Array[Byte] => Task[Array[Byte]]] =
         channel lift { toTask =>

--- a/src/test/scala/scalaz/stream/Utf8DecodeSpec.scala
+++ b/src/test/scala/scalaz/stream/Utf8DecodeSpec.scala
@@ -63,7 +63,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   // https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
   // 2.1 First possible sequence of a certain length
-  property("2.1") = secure {
+  property("2.1") = protect {
     ("2.1.1" |: checkBytes(0x00)) &&
     ("2.1.2" |: checkBytes(0xc2, 0x80)) &&
     ("2.1.3" |: checkBytes(0xe0, 0xa0, 0x80)) &&
@@ -73,7 +73,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 2.2 Last possible sequence of a certain length
-  property("2.2") = secure {
+  property("2.2") = protect {
     ("2.2.1" |: checkBytes(0x7f)) &&
     ("2.2.2" |: checkBytes(0xdf, 0xbf)) &&
     ("2.2.3" |: checkBytes(0xef, 0xbf, 0xbf)) &&
@@ -83,7 +83,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 2.3 Other boundary conditions
-  property("2.3") = secure {
+  property("2.3") = protect {
     ("2.3.1" |: checkBytes(0xed, 0x9f, 0xbf)) &&
     ("2.3.2" |: checkBytes(0xee, 0x80, 0x80)) &&
     ("2.3.3" |: checkBytes(0xef, 0xbf, 0xbd)) &&
@@ -92,20 +92,20 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 3.1 Unexpected continuation bytes
-  property("3.1") = secure {
+  property("3.1") = protect {
     ("3.1.1" |: checkBytes(0x80)) &&
     ("3.1.2" |: checkBytes(0xbf))
   }
 
   // 3.5 Impossible bytes
-  property("3.5") = secure {
+  property("3.5") = protect {
     ("3.5.1" |: checkBytes(0xfe)) &&
     ("3.5.2" |: checkBytes(0xff)) &&
     ("3.5.3" |: checkBytes2(0xfe, 0xfe, 0xff, 0xff))
   }
 
   // 4.1 Examples of an overlong ASCII character
-  property("4.1") = secure {
+  property("4.1") = protect {
     ("4.1.1" |: checkBytes(0xc0, 0xaf)) &&
     ("4.1.2" |: checkBytes(0xe0, 0x80, 0xaf)) &&
     ("4.1.3" |: checkBytes(0xf0, 0x80, 0x80, 0xaf)) &&
@@ -114,7 +114,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 4.2 Maximum overlong sequences
-  property("4.2") = secure {
+  property("4.2") = protect {
     ("4.2.1" |: checkBytes(0xc1, 0xbf)) &&
     ("4.2.2" |: checkBytes(0xe0, 0x9f, 0xbf)) &&
     ("4.2.3" |: checkBytes(0xf0, 0x8f, 0xbf, 0xbf)) &&
@@ -123,7 +123,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 4.3 Overlong representation of the NUL character
-  property("4.3") = secure {
+  property("4.3") = protect {
     ("4.3.1" |: checkBytes(0xc0, 0x80)) &&
     ("4.3.2" |: checkBytes(0xe0, 0x80, 0x80)) &&
     ("4.3.3" |: checkBytes(0xf0, 0x80, 0x80, 0x80)) &&
@@ -132,7 +132,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 5.1 Single UTF-16 surrogates
-  property("5.1") = secure {
+  property("5.1") = protect {
     ("5.1.1" |: checkBytes(0xed, 0xa0, 0x80)) &&
     ("5.1.2" |: checkBytes(0xed, 0xad, 0xbf)) &&
     ("5.1.3" |: checkBytes(0xed, 0xae, 0x80)) &&
@@ -143,7 +143,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 5.2 Paired UTF-16 surrogates
-  property("5.2") = secure {
+  property("5.2") = protect {
     ("5.2.1" |: checkBytes2(0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80)) &&
     ("5.2.2" |: checkBytes2(0xed, 0xa0, 0x80, 0xed, 0xbf, 0xbf)) &&
     ("5.2.3" |: checkBytes2(0xed, 0xad, 0xbf, 0xed, 0xb0, 0x80)) &&
@@ -155,7 +155,7 @@ class Utf8DecodeSpec extends Properties("text.utf8Decode") {
   }
 
   // 5.3 Other illegal code positions
-  property("5.3") = secure {
+  property("5.3") = protect {
     ("5.3.1" |: checkBytes(0xef, 0xbf, 0xbe)) &&
     ("5.3.2" |: checkBytes(0xef, 0xbf, 0xbf))
   }


### PR DESCRIPTION
Scalacheck 1.12.4 instantiates an instance of test classes for
each property to be evaluated. Using `protect` instead of `secure`
makes the property evaluation lazy, to avoid doing a lot of extra
work here.