### PR TITLE
Updated to Scala 2.11.7 and 2.12.0-M1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: scala
 sbt_args: -J-Dproject.version=travis-SNAPSHOT
 scala:
   - 2.10.5
-  - 2.11.6
+  - 2.11.7
+  - 2.12.0-M1
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ git.gitTagToVersionNumber := {
   case _ => None
 }
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M1")
 
 scalacOptions ++= Seq(
   "-feature",
@@ -37,7 +37,7 @@ resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snap
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.1.2",
   "org.scalaz" %% "scalaz-concurrent" % "7.1.2",
-  "org.scodec" %% "scodec-bits" % "1.0.6",
+  "org.scodec" %% "scodec-bits" % "1.0.9",
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.2" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.4" % "test"
 )


### PR DESCRIPTION
Step one of a three step process.  Step two is rebasing this back to `series/0.7` and `series/0.7a`, and step three is actually pushing the release to Sonatype.