### PR TITLE
Fix resource safety for `wye`, fixes #424

### DIFF
--- a/src/main/scala/scalaz/stream/wye.scala
+++ b/src/main/scala/scalaz/stream/wye.scala
@@ -674,7 +674,7 @@ object wye {
             Either3.middle3((_: Cause) => ()) //rest the interrupt so it won't get interrupted again
 
           case Right3(cont) =>
-            (Halt(Kill) +: cont) stepAsync { _ => a ! Ready[A](side, -\/(Kill)) }
+            (Halt(Kill) +: cont) stepAsync { res => a ! Ready[A](side, res) }
             Either3.middle3((_: Cause) => ()) // no-op cleanup can't be interrupted
 
           case left@Left3(_) =>

--- a/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
+++ b/src/test/scala/scalaz/stream/ResourceSafetySpec.scala
@@ -1,13 +1,14 @@
 package scalaz.stream
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import Cause._
 import org.scalacheck._
 import Prop._
 
 import scalaz.concurrent.Task
-import java.util.concurrent.{ConcurrentLinkedQueue, LinkedBlockingDeque}
+import java.util.concurrent.{CountDownLatch, TimeUnit, Semaphore, ConcurrentLinkedQueue}
 import Process._
-import scalaz.-\/
 import scalaz.\/._
 
 
@@ -31,7 +32,6 @@ class ResourceSafetySpec extends Properties("resource-safety") {
   val boom = new java.lang.Exception("boom!")
 
   def die = throw bwah
-
 
   property("cleanups") = protect {
     import Process._
@@ -90,5 +90,25 @@ class ResourceSafetySpec extends Properties("resource-safety") {
     var cleaned = false
     (emit(1) onComplete eval_(Task.delay(cleaned = true))).kill.kill.kill.expectedCause(_ == Kill).run.run
     cleaned
+  }
+
+  property("cleanups for combination of wye, tee and pipe") = forAll { xs: List[Boolean] =>
+    val semaphore = new Semaphore(1)
+
+    Process.emitAll(xs).wye(
+      for {
+        _ <- {
+          val acquire = Task delay { semaphore.acquire()  }
+          val release = Task delay { semaphore.release() }
+
+          io.resource(acquire)(x => release)(Task.now)
+        }
+        x <- emit(1).zip(emit(2).pipe(process1.id[Int]))
+      } yield x
+    )(wye.interrupt).run.run
+
+    val acquired = semaphore.tryAcquire(3, TimeUnit.SECONDS)
+
+    (acquired && semaphore.availablePermits() == 0) :| "acquired didn't imply released"
   }
 }


### PR DESCRIPTION
This pull request fixes #424. @djspiewak could you please take a look?

The original issue has been solved. I've added a spec covering it.

But... sometimes this spec fails. It doesn't fail if we add `Thread.sleep(100)` after `.run.run` and constantly fails if we add `Thread.sleep(1000)` to `release` task. It looks like `.run.run` doesn't wait for termination of `release` task. I feel it is another issue.

I don't know how to fix this. Probably if changes to `wye` are good, we can merge it without a spec and fix it later. Any suggestions?