### PR TITLE
Add MiMa compability plugin to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,25 @@ OsgiKeys.importPackage := Seq(
   "*"
 )
 
+val ignoredABIProblems = {
+  import com.typesafe.tools.mima.core._
+  import com.typesafe.tools.mima.core.ProblemFilters._
+
+  Seq()
+}
+
+lazy val mimaSettings = {
+  import com.typesafe.tools.mima.plugin.MimaKeys.{binaryIssueFilters, previousArtifact}
+  import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
+
+  mimaDefaultSettings ++ Seq(
+    previousArtifact := MiMa.targetVersion(version.value).map(organization.value %% name.value % _),
+    binaryIssueFilters ++= ignoredABIProblems
+  )
+}
+
+mimaSettings
+
 parallelExecution in Test := false
 
 autoAPIMappings := true

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -1,0 +1,57 @@
+case class LibraryVersion(major: Int, minor: Int, patch: Option[Int], suffix: Option[String]) {
+  override def toString = {
+    s"$major.$minor" +
+      patch.fold("")("." + _) +
+      suffix.fold("")("-" + _)
+  }
+}
+
+object MiMa {
+  // Matches versions like "0.8", "0.8.1", "0.8.1-SNAPSHOT", "0.8.1-3-53de4b5d"
+  def extractVersion(version: String): Option[LibraryVersion] = {
+    val VersionExtractor = """(\d+)\.(\d+)(?:\.(\d+))?(?:-(.*))?""".r
+    version match {
+      case VersionExtractor(major, minor, patch, suffix) =>
+        Some(LibraryVersion(major.toInt, minor.toInt, Option(patch).map(_.toInt), Option(suffix)))
+      case _ => None
+    }
+  }
+
+  // RC and SNAPSHOT suffixes represent pre-release builds,
+  // cannot check compatibility against unreleased software.
+  def suffixAfterRelease(version: LibraryVersion): Boolean = {
+    version.suffix match {
+      case Some(s) if s.startsWith("RC") => false
+      case Some(s) if s == "SNAPSHOT" => false
+      case None => false
+      case _ => true
+    }
+  }
+
+  // Return version of library to check for compatibility
+  def targetLibraryVersion(currentVersion: LibraryVersion): Option[LibraryVersion] = {
+    // Default target version has patch 0, no suffix.
+    // e.g. "0.8.1-SNAPSHOT" is compared with "0.8.0"
+    val targetVersion = currentVersion.copy(patch = Some(0), suffix = None)
+
+    val shouldCheck: Boolean =
+      (currentVersion.patch, targetVersion.patch, suffixAfterRelease(currentVersion)) match {
+        case (Some(current), Some(target), _) if current > target => true
+        case (Some(current), Some(target), suffix) if current == target => suffix
+        case (Some(current), None, _) => true
+        case _ => false
+      }
+
+    if (shouldCheck)
+      Some(targetVersion)
+    else
+      None
+  }
+
+  def targetVersion(currentVersion: String): Option[String] = {
+    for {
+      version <- extractVersion(currentVersion)
+      target <- targetLibraryVersion(version)
+    } yield target.toString
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.3.3")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")


### PR DESCRIPTION
I don't think there's a nice way of checking which branch we're on, and selecting the appropriate version on that basis (for example, we only want to check against 0.7.2a on the `series/0.7a` branch).

Instead, it should be easy to override behaviour per-branch.

Set `checkABICompatibilityVersion` to define which version to check.
Set `ignoredABIProblems` to define what ABI issues to ignore.
Check with `sbt mimaReportBinaryIssues`

This cherry-picks cleanly to `series/0.7a`.