### PR TITLE
FS2: Add Process1Spec that tests the current transducers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-concurrent" % "7.1.3",
   "org.scodec" %% "scodec-bits" % "1.0.9",
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.3" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.12.4" % "test"
+  "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
 )
 
 sonatypeProfileName := "org.scalaz"
@@ -105,9 +105,10 @@ parallelExecution in Test := false
 
 autoAPIMappings := true
 
-apiURL := Some(url(s"http://docs.typelevel.org/api/scalaz-stream/stable/${version.value}/doc/"))
-
-initialCommands := "import scalaz.stream._"
+initialCommands := s"""
+  import fs2._
+  import fs2.util._
+"""
 
 doctestWithDependencies := false
 

--- a/src/main/scala/fs2/StreamDerived.scala
+++ b/src/main/scala/fs2/StreamDerived.scala
@@ -43,6 +43,8 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
 
   def emit[F[_],A](a: A): Stream[F,A] = chunk(Chunk.singleton(a))
 
+  def emitAll[F[_],A](as: Seq[A]): Stream[F,A] = chunk(Chunk.seq(as))
+
   def suspend[F[_],A](s: => Stream[F,A]): Stream[F,A] =
     flatMap(emit(())) { _ => try s catch { case t: Throwable => fail(t) } }
 

--- a/src/test/scala/fs2/Process1Spec.scala
+++ b/src/test/scala/fs2/Process1Spec.scala
@@ -1,0 +1,25 @@
+package fs2
+
+import fs2.Stream._
+import fs2.TestUtil._
+import fs2.process1._
+import org.scalacheck.Prop._
+import org.scalacheck.{Gen, Properties}
+
+class Process1Spec extends Properties("process1") {
+
+  property("last") = forAll { (v: Vector[Int]) =>
+    emitAll(v).pipe(last) ==? Vector(v.lastOption)
+  }
+
+  property("lift") = forAll { (v: Vector[Int]) =>
+    emitAll(v).pipe(lift(_.toString)) ==? v.map(_.toString)
+  }
+
+  property("take") = forAll { (v: Vector[Int]) =>
+    val n = Gen.choose(-1, 20).sample.get
+    emitAll(v).pipe(take(n)) ==? v.take(n)
+  }
+
+  // TODO: test chunkiness. How do we do this?
+}

--- a/src/test/scala/fs2/StreamsSpec.scala
+++ b/src/test/scala/fs2/StreamsSpec.scala
@@ -5,6 +5,7 @@ import org.scalacheck._
 
 import java.util.concurrent.atomic.AtomicInteger
 import fs2.util._
+import fs2.TestUtil._
 
 class StreamsSpec extends Properties("Stream") {
 
@@ -143,20 +144,10 @@ class StreamsSpec extends Properties("Stream") {
     println(msg + " took " + total + " milliseconds")
     result
   }
-  def run[A](s: Stream[Task,A]): Vector[A] = s.runLog.run.run
 
   def throws[A](err: Throwable)(s: Stream[Task,A]): Boolean =
     s.runLog.run.attemptRun match {
       case Left(e) if e == err => true
       case _ => false
     }
-
-  implicit class EqualsOp[A](s: Stream[Task,A]) {
-    def ===(v: Vector[A]) = run(s) == v
-    def ==?(v: Vector[A]) = {
-      val l = run(s)
-      val r = v
-      l == r || { println("left: " + l); println("right: " + r); false }
-    }
-  }
 }

--- a/src/test/scala/fs2/TestUtil.scala
+++ b/src/test/scala/fs2/TestUtil.scala
@@ -1,0 +1,17 @@
+package fs2
+
+import fs2.util.Task
+
+object TestUtil {
+
+  def run[A](s: Stream[Task,A]): Vector[A] = s.runLog.run.run
+
+  implicit class EqualsOp[A](s: Stream[Task,A]) {
+    def ===(v: Vector[A]) = run(s) == v
+    def ==?(v: Vector[A]) = {
+      val l = run(s)
+      val r = v
+      l == r || { println("left: " + l); println("right: " + r); false }
+    }
+  }
+}


### PR DESCRIPTION
This adds basic tests for `process1.{lift, last, take}`. One interesting question here: how can I test if `take` preserves the chunkiness of the input? I've also added `emitAll` which is nicer to use than `Stream(v: _*)`.