### PR TITLE
FS2: Test that take preserves the chunkiness of the input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: scala
 sbt_args: -J-Dproject.version=travis-SNAPSHOT
 scala:
-  - 2.10.5
   - 2.11.7
-  - 2.12.0-M1
   - 2.12.0-M2
 jdk:
   # - oraclejdk7

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ git.gitTagToVersionNumber := {
 
 scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M1", "2.12.0-M2")
+crossScalaVersions := Seq("2.11.7", "2.12.0-M2")
 
 scalacOptions ++= Seq(
   "-feature",

--- a/src/test/scala/fs2/Process1Spec.scala
+++ b/src/test/scala/fs2/Process1Spec.scala
@@ -8,6 +8,11 @@ import org.scalacheck.{Gen, Properties}
 
 class Process1Spec extends Properties("process1") {
 
+  property("chunks") = forAll(nonEmptyNestedVectorGen) { (v: Vector[Vector[Int]]) =>
+    val s = v.map(emitAll).reduce(_ ++ _)
+    s.pipe(chunks).map(_.toVector) ==? v
+  }
+
   property("last") = forAll { (v: Vector[Int]) =>
     emitAll(v).pipe(last) ==? Vector(v.lastOption)
   }
@@ -21,5 +26,8 @@ class Process1Spec extends Properties("process1") {
     emitAll(v).pipe(take(n)) ==? v.take(n)
   }
 
-  // TODO: test chunkiness. How do we do this?
+  property("take.chunks") = secure {
+    val s = Stream(1, 2) ++ Stream(3, 4)
+    s.pipe(take(3)).pipe(chunks).map(_.toVector) ==? Vector(Vector(1, 2), Vector(3))
+  }
 }

--- a/src/test/scala/fs2/TestUtil.scala
+++ b/src/test/scala/fs2/TestUtil.scala
@@ -1,6 +1,7 @@
 package fs2
 
 import fs2.util.Task
+import org.scalacheck.{Arbitrary, Gen}
 
 object TestUtil {
 
@@ -14,4 +15,11 @@ object TestUtil {
       l == r || { println("left: " + l); println("right: " + r); false }
     }
   }
+
+  val nonEmptyNestedVectorGen = for {
+    sizeOuter <- Gen.choose(1, 10)
+    sizeInner <- Gen.choose(1, 10)
+    inner = Gen.listOfN(sizeInner, Arbitrary.arbInt.arbitrary).map(_.toVector)
+    outer <- Gen.listOfN(sizeOuter, inner).map(_.toVector)
+  } yield outer
 }


### PR DESCRIPTION
This adds `process1.chunks` which is used to test that `take` preserves the chunkiness of its input.

What I observed here:
* The actual `Process1` definition feels like 100% boilerplate:
```scala
def chunks[I]: Process1[I,Chunk[I]] =
  new Process1[I,Chunk[I]] { def run[F[_]] = _.pull[F,Chunk[I]](pull.chunks) }
```
* If you leave out the type parameter in `_.pull[F,Chunk[I]](...)`, you get weird compiler errors.
* I had to repeat `Chunk[I]` there three times
* `Chunk` has no sensible `equals`:
```scala
scala> val x = Chunk.singleton(1) == Chunk.singleton(1)
x: Boolean = false
```