### PR TITLE
Fix typo

### DIFF
--- a/src/main/scala/scalaz/stream/time.scala
+++ b/src/main/scala/scalaz/stream/time.scala
@@ -14,7 +14,7 @@ object time {
    * since the start time of stream consumption.
    *
    * For example: `awakeEvery(5 seconds)` will
-   * return (approximately) `5s, 10s, 20s`, and will lie dormant
+   * return (approximately) `5s, 10s, 15s, ...`, and will lie dormant
    * between emitted values.
    *
    * By default, this uses a shared `ScheduledExecutorService`


### PR DESCRIPTION
`awakeEvery(5 seconds)` should return at 5s, 10s, and 15s, right?  There's also nothing shown here that limits it to three output values, right?