### PR TITLE
Add shortcut for h => h.await.flatMap?

### DIFF
--- a/src/main/scala/fs2/Process1.scala
+++ b/src/main/scala/fs2/Process1.scala
@@ -16,24 +16,18 @@ object process1 {
 
   // nb: methods are in alphabetical order
 
-  def receive[F[_],I,O](f: Step[Chunk[I],Handle[F, I]] => Pull[F,O,Handle[F,I]]): Handle[F,I] => Pull[F,O,Handle[F,I]] =
-    _.await.flatMap(f)
-
-  def receive1[F[_],I,O](f: Step[I,Handle[F, I]] => Pull[F,O,Handle[F,I]]): Handle[F,I] => Pull[F,O,Handle[F,I]] =
-    _.await1.flatMap(f)
-
   /** Output all chunks from the input `Handle`. */
   def chunks[F[_],I](implicit F: NotNothing[F]): Handle[F,I] => Pull[F,Chunk[I],Handle[F,I]] =
-    receive { case chunk #: h => Pull.output1(chunk) >> chunks.apply(h) }
+    Pull.receive { case chunk #: h => Pull.output1(chunk) >> chunks.apply(h) }
 
   /** Output a transformed version of all chunks from the input `Handle`. */
   def mapChunks[F[_],I,O](f: Chunk[I] => Chunk[O])(implicit F: NotNothing[F])
   : Handle[F,I] => Pull[F,O,Handle[F,I]]
-  = receive { case chunk #: h => Pull.output(f(chunk)) >> mapChunks(f).apply(h) }
+  = Pull.receive { case chunk #: h => Pull.output(f(chunk)) >> mapChunks(f).apply(h) }
 
   /** Skip the first element that matches the predicate. */
   def delete[F[_],I](p: I => Boolean)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive { case chunk #: h =>
+    Pull.receive { case chunk #: h =>
       chunk.indexWhere(p) match {
         case Some(i) =>
           val (before, after) = (chunk.take(i), chunk.drop(i + 1))
@@ -59,7 +53,7 @@ object process1 {
    * Works in a chunky fashion and creates a `Chunk.indexedSeq` for each mapped chunk.
    */
   def lift[F[_],I,O](f: I => O)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,O,Handle[F,I]] =
-    receive { case chunk #: h => Pull.output(chunk map f) >> lift(f).apply(h) }
+    Pull.receive { case chunk #: h => Pull.output(chunk map f) >> lift(f).apply(h) }
 
   /** Emit the first `n` elements of the input `Handle` and return the new `Handle`. */
   def take[F[_],I](n: Long)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
@@ -102,7 +96,7 @@ object process1 {
       
   /** Convert the input to a stream of solely 1-element chunks. */
   def unchunk[F[_],I](implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
-    receive1 { case i #: h => Pull.output1(i) >> unchunk.apply(h) }
+    Pull.receive1 { case i #: h => Pull.output1(i) >> unchunk.apply(h) }
 
   // stepping a process
 


### PR DESCRIPTION
This is a question. In scalaz-stream we have `receive1` which is the same as `await1.flatMap`. Do we want something similar here? `h => h.await flatMap ` is already a recurring pattern.