### PR TITLE
Build with Scala 2.12.0-M3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sbt_args: -J-Dproject.version=travis-SNAPSHOT
 scala:
   - 2.10.5
   - 2.11.7
-  - 2.12.0-M2
+  - 2.12.0-M3
 jdk:
   # - oraclejdk7
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ git.formattedShaVersion := {
 
 scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M2")
+crossScalaVersions := Seq("2.10.5", "2.11.7", "2.12.0-M3")
 
 scalacOptions ++= Seq(
   "-feature",
@@ -48,7 +48,7 @@ resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snap
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.1.4",
   "org.scalaz" %% "scalaz-concurrent" % "7.1.4",
-  "org.scodec" %% "scodec-bits" % "1.0.9",
+  "org.scodec" %% "scodec-bits" % "1.0.10",
   "org.scalaz" %% "scalaz-scalacheck-binding" % "7.1.4" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
 )


### PR DESCRIPTION
The build will fail because ScalaCheck is not yet available for 2.12.0-M3:
```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.scalacheck#scalacheck_2.12.0-M3;1.12.5: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
```
But a local build without ScalaCheck went just fine.

/cc @SethTisue 