### PR TITLE
FS2: Implement process1.scan, process1.scan1, process1.fold, process1.fold1

### DIFF
--- a/src/main/scala/fs2/Chunk.scala
+++ b/src/main/scala/fs2/Chunk.scala
@@ -29,14 +29,9 @@ trait Chunk[+A] { self =>
     iterator.map(f).copyToBuffer(buf)
     Chunk.indexedSeq(buf)
   }
-  /**
-   * `[[scanLeft]]` is a helper for process1.scan; it differs
-   * from standard collection behavior by not including
-   * the initial value in the output.
-   */
   def scanLeft[B](z: B)(f: (B, A) => B): Chunk[B] = {
-    val buf = new collection.mutable.ArrayBuffer[B](size)
-    iterator.scanLeft(z)(f).drop(1).copyToBuffer(buf)
+    val buf = new collection.mutable.ArrayBuffer[B](size + 1)
+    iterator.scanLeft(z)(f).copyToBuffer(buf)
     Chunk.indexedSeq(buf)
   }
   def zipWithIndex: Chunk[(A, Int)] = {

--- a/src/main/scala/fs2/Chunk.scala
+++ b/src/main/scala/fs2/Chunk.scala
@@ -29,6 +29,16 @@ trait Chunk[+A] { self =>
     iterator.map(f).copyToBuffer(buf)
     Chunk.indexedSeq(buf)
   }
+  /**
+   * `[[scanLeft]]` is a helper for process1.scan; it differs
+   * from standard collection behavior by not including
+   * the initial value in the output.
+   */
+  def scanLeft[B](z: B)(f: (B, A) => B): Chunk[B] = {
+    val buf = new collection.mutable.ArrayBuffer[B](size)
+    iterator.scanLeft(z)(f).drop(1).copyToBuffer(buf)
+    Chunk.indexedSeq(buf)
+  }
   def zipWithIndex: Chunk[(A, Int)] = {
     val buf = new collection.mutable.ArrayBuffer[(A, Int)](size)
     iterator.zipWithIndex.copyToBuffer(buf)

--- a/src/main/scala/fs2/Process1.scala
+++ b/src/main/scala/fs2/Process1.scala
@@ -40,6 +40,23 @@ object process1 {
   def filter[F[_],I](f: I => Boolean)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
     mapChunks(_ filter f)
 
+  /**
+   * Folds all inputs using an initial value `z` and supplied binary operator, and writes the final
+   * result to the output of the supplied `Pull` when the stream has no more values.
+   */
+  def fold[F[_],I,O](z: O)(f: (O, I) => O)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,O,Handle[F,I]] =
+   h => h.await.optional flatMap {
+     case Some(c #: h) => fold(c.foldLeft(z)(f))(f).apply(h)
+     case None => Pull.output1(z) >> Pull.done
+   }
+
+  /**
+   * Folds all inputs using the supplied binary operator, and writes the final result to the output of
+   * the supplied `Pull` when the stream has no more values.
+   */
+  def fold1[F[_],I](f: (I, I) => I)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
+    Pull.receive1 { case o #: h => fold(o)(f).apply(h) }
+
   /** Write all inputs to the output of the returned `Pull`. */
   def id[F[_],I](implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
     Pull.echo[F,I]
@@ -54,6 +71,30 @@ object process1 {
    */
   def lift[F[_],I,O](f: I => O)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,O,Handle[F,I]] =
     mapChunks(_.map(f))
+
+  /** Alias for `[[process1.fold1]]` */
+  def reduce[F[_],I](f: (I, I) => I)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
+    fold1(f)
+
+  /**
+   * Writes `z` to the output, followed by the result of repeated applications of `f` to each input in turn.
+   * Works in a chunky fashion, and creates a `Chunk.indexedSeq` for each converted chunk.
+   */
+  def scan[F[_],I,O](z: O)(f: (O, I) => O)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,O,Handle[F,I]] = {
+    def go(z: O): Handle[F,I] => Pull[F,O,Handle[F,I]] =
+      Pull.receive { case chunk #: h =>
+        val s = chunk.scanLeft(z)(f)
+        Pull.output(s) >> go(s(s.size - 1)).apply(h)
+      }
+    h => Pull.output1(z) >> go(z).apply(h)
+  }
+
+  /**
+   * Writes the result of repeated applications of `f` to each input in turn.
+   * Works in a chunky fashion, and creates a `Chunk.indexedSeq` for each converted chunk.
+   */
+  def scan1[F[_],I](f: (I, I) => I)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =
+    Pull.receive1 { case o #: h => scan(o)(f).apply(h) }
 
   /** Emit the first `n` elements of the input `Handle` and return the new `Handle`. */
   def take[F[_],I](n: Long)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,I,Handle[F,I]] =

--- a/src/main/scala/fs2/Process1.scala
+++ b/src/main/scala/fs2/Process1.scala
@@ -83,7 +83,7 @@ object process1 {
   def scan[F[_],I,O](z: O)(f: (O, I) => O)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,O,Handle[F,I]] = {
     def go(z: O): Handle[F,I] => Pull[F,O,Handle[F,I]] =
       Pull.receive { case chunk #: h =>
-        val s = chunk.scanLeft(z)(f)
+        val s = chunk.scanLeft(z)(f).drop(1)
         Pull.output(s) >> go(s(s.size - 1)).apply(h)
       }
     h => Pull.output1(z) >> go(z).apply(h)

--- a/src/main/scala/fs2/Process1Ops.scala
+++ b/src/main/scala/fs2/Process1Ops.scala
@@ -19,11 +19,26 @@ trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
   /** Alias for `self pipe [[process1.filter]]`. */
   def filter(f: O => Boolean): Stream[F,O] = self pipe process1.filter(f)
 
+  /** Alias for `self pipe [[process1.fold]](z)(f)`. */
+  def fold[O2](z: O2)(f: (O2, O) => O2): Stream[F,O2] = self pipe process1.fold(z)(f)
+
+  /** Alias for `self pipe [[process1.fold1]](f)`. */
+  def fold1[O2 >: O](f: (O2, O2) => O2): Stream[F,O2] = self pipe process1.fold1(f)
+
   /** Alias for `self pipe [[process1.last]]`. */
   def last: Stream[F,Option[O]] = self pipe process1.last
 
   /** Alias for `self pipe [[process1.mapChunks]](f)`. */
   def mapChunks[O2](f: Chunk[O] => Chunk[O2]): Stream[F,O2] = self pipe process1.mapChunks(f)
+
+  /** Alias for `self pipe [[process1.reduce]](z)(f)`. */
+  def reduce[O2 >: O](f: (O2, O2) => O2): Stream[F,O2] = self pipe process1.reduce(f)
+
+  /** Alias for `self pipe [[process1.scan]](z)(f)`. */
+  def scan[O2](z: O2)(f: (O2, O) => O2): Stream[F,O2] = self pipe process1.scan(z)(f)
+
+  /** Alias for `self pipe [[process1.scan1]](f)`. */
+  def scan1[O2 >: O](f: (O2, O2) => O2): Stream[F,O2] = self pipe process1.scan1(f)
 
   /** Alias for `self pipe [[process1.take]](n)`. */
   def take(n: Long): Stream[F,O] = self pipe process1.take(n)


### PR DESCRIPTION
process1.fold:
  Folds all inputs using an initial value `z` and supplied binary operator,
  and writes the final result to the output of the supplied `Pull` when the
  stream has no more values.

process1.fold1:
  Folds all inputs using the supplied binary operator, and writes the final
  result to the output of the supplied `Pull` when the stream has no more values.

process1.scan:
   Writes `z` to the output, followed by the result of repeated applications
   of `f` to each input in turn. Works in a chunky fashion, and creates a
  `Chunk.indexedSeq` for each converted chunk.

process1.scan1:
  Writes the result of repeated applications of `f` to each input in turn.
  Works in a chunky fashion, and creates a `Chunk.indexedSeq` for each
  converted chunk.