### PR TITLE
FS2: Add process1.mapAccumulate

### DIFF
--- a/src/main/scala/fs2/Chunk.scala
+++ b/src/main/scala/fs2/Chunk.scala
@@ -34,6 +34,16 @@ trait Chunk[+A] { self =>
     iterator.map(f).copyToBuffer(buf)
     Chunk.indexedSeq(buf)
   }
+  def mapAccumulate[S,B](s0: S)(f: (S,A) => (S,B)): (S,Chunk[(S,B)]) = {
+    val buf = new collection.mutable.ArrayBuffer[(S,B)](size)
+    var s = s0
+    for { c <- iterator } {
+      val r = f(s, c)
+      buf += r
+      s = r._1
+    }
+    (s, Chunk.indexedSeq(buf))
+  }
   def scanLeft[B](z: B)(f: (B, A) => B): Chunk[B] = {
     val buf = new collection.mutable.ArrayBuffer[B](size + 1)
     iterator.scanLeft(z)(f).copyToBuffer(buf)

--- a/src/main/scala/fs2/Chunk.scala
+++ b/src/main/scala/fs2/Chunk.scala
@@ -34,13 +34,13 @@ trait Chunk[+A] { self =>
     iterator.map(f).copyToBuffer(buf)
     Chunk.indexedSeq(buf)
   }
-  def mapAccumulate[S,B](s0: S)(f: (S,A) => (S,B)): (S,Chunk[(S,B)]) = {
-    val buf = new collection.mutable.ArrayBuffer[(S,B)](size)
+  def mapAccumulate[S,B](s0: S)(f: (S,A) => (S,B)): (S,Chunk[B]) = {
+    val buf = new collection.mutable.ArrayBuffer[B](size)
     var s = s0
     for { c <- iterator } {
-      val r = f(s, c)
-      buf += r
-      s = r._1
+      val (newS, newC) = f(s, c)
+      buf += newC
+      s = newS
     }
     (s, Chunk.indexedSeq(buf))
   }

--- a/src/main/scala/fs2/Process1.scala
+++ b/src/main/scala/fs2/Process1.scala
@@ -77,6 +77,26 @@ object process1 {
     _ repeatPull { _.await.flatMap { case chunk #: h => Pull.output(f(chunk)) as h }}
 
   /**
+    * Maps a running total according to `S` and the input with the function `f`.
+    *
+    * @example {{{
+    * scala> Stream("Hello", "World")
+    *      |   .mapAccumulate(0)((l, s) => (l + s.length, s.head)).toVector
+    * res0: Vector[(Int, Char)] = Vector((5,H), (10,W))
+    * }}}
+    */
+  def mapAccumulate[F[_],S,I,O](init: S)(f: (S,I) => (S,O)): Stream[F,I] => Stream[F,(S,O)] =
+    _ pull { _.await.flatMap { case chunk #: h =>
+      val (s, o) = chunk.mapAccumulate(init)(f)
+      Pull.output(o) >> _mapAccumulate0(s)(f)(h)
+    }}
+  private def _mapAccumulate0[F[_],S,I,O](init: S)(f: (S,I) => (S,O)): Handle[F,I] => Pull[F,(S,O),Handle[F,I]] =
+    Pull.receive { case chunk #: h =>
+      val (s, o) = chunk.mapAccumulate(init)(f)
+      Pull.output(o) >> _mapAccumulate0(s)(f)(h)
+    }
+
+  /**
    * Behaves like `id`, but starts fetching the next chunk before emitting the current,
    * enabling processing on either side of the `prefetch` to run in parallel.
    */

--- a/src/main/scala/fs2/Process1Ops.scala
+++ b/src/main/scala/fs2/Process1Ops.scala
@@ -39,6 +39,10 @@ trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
   /** Alias for `self pipe [[process1.mapChunks]](f)`. */
   def mapChunks[O2](f: Chunk[O] => Chunk[O2]): Stream[F,O2] = self pipe process1.mapChunks(f)
 
+  /** Alias for `self pipe [[process1.mapAccumulate]]` */
+  def mapAccumulate[S,O2](init: S)(f: (S, O) => (S, O2)): Stream[F, (S, O2)] =
+    self pipe process1.mapAccumulate(init)(f)
+
   /** Alias for `self pipe [[process1.reduce]](z)(f)`. */
   def reduce[O2 >: O](f: (O2, O2) => O2): Stream[F,O2] = self pipe process1.reduce(f)
 

--- a/src/test/scala/fs2/Process1Spec.scala
+++ b/src/test/scala/fs2/Process1Spec.scala
@@ -113,6 +113,14 @@ object Process1Spec extends Properties("process1") {
     s.get.pipe(lift(_.toString)) ==? run(s.get).map(_.toString)
   }
 
+  property("mapAccumulate") = forAll { (s: PureStream[Int], n0: Int, n1: SmallPositive) =>
+    val f = (_: Int) % n1.get == 0
+    val r = s.get.mapAccumulate(n0)((s, i) => (s + i, f(i)))
+
+    r.map(_._1) ==? run(s.get).scan(n0)(_ + _).tail
+    r.map(_._2) ==? run(s.get).map(f)
+  }
+
   property("prefetch") = forAll { (s: PureStream[Int]) =>
     s.get.covary[Task].through(prefetch) ==? run(s.get)
   }


### PR DESCRIPTION
@pchiusano This isn't ready to be committed (needs a bit more review, tests, and comments), but I wanted to check that you'd be happy with the general approach.

I think it can probably be used by a lot of other combinators, e.g. a sample implementation of sliding:
```scala
def sliding[F[_],I](n: Int)(implicit F: NotNothing[F]): Handle[F,I] => Pull[F,IndexedSeq[I],Handle[F,I]] =
  collectAccumulate(new collection.mutable.ArrayBuffer[I](n))((arr, i: I) => {
    arr += i
    if (arr.size >= n) {
      val newArr = new collection.mutable.ArrayBuffer[I](n)
      arr.tail.copyToBuffer(newArr)
      (newArr, Some(arr))
    } else (arr, None)
  })(s => None)
```

Also I'm not sure about the name :smile:  