### PR TITLE
Resource safety test suite

### DIFF
--- a/src/main/scala/fs2/Stream.scala
+++ b/src/main/scala/fs2/Stream.scala
@@ -133,7 +133,7 @@ object Stream extends Streams[Stream] with StreamDerived {
     def _stepAsync1[F2[_],W2>:W](rights: List[Stream[F2,W2]])(
       implicit S: Sub1[F,F2], F2: Async[F2])
       : Pull[F2,Nothing,Future[F2, Pull[F2,Nothing,Step[Chunk[W2], Stream.Handle[F2,W2]]]]]
-      = _step1(rights).map(step => Future.pure(Pull.pure(step)))
+      = Pull.pure(Future.pure(_step1(rights)))
 
     def translate[G[_]](uf1: F ~> G): Stream[G,W] = chunk[G,W](c)
 
@@ -169,7 +169,7 @@ object Stream extends Streams[Stream] with StreamDerived {
     def _stepAsync1[F2[_],W2>:W](rights: List[Stream[F2,W2]])(
       implicit S: Sub1[F,F2], F2: Async[F2])
       : Pull[F2,Nothing,Future[F2, Pull[F2,Nothing,Step[Chunk[W2], Stream.Handle[F2,W2]]]]]
-      = Pull.fail(err)
+      = Pull.pure(Future.pure(Pull.fail(err)))
 
     def translate[G[_]](uf1: F ~> G): Stream[G,W] = self.asInstanceOf[Stream[G,W]]
   }

--- a/src/main/scala/fs2/StreamDerived.scala
+++ b/src/main/scala/fs2/StreamDerived.scala
@@ -83,16 +83,6 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
       Pull[F2, Nothing, AsyncStep[F2,A2]] = self.awaitAsync(Sub1.substHandle(h))
     def await1Async[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]):
       Pull[F2, Nothing, AsyncStep1[F2,A2]] = self.await1Async(Sub1.substHandle(h))
-    def ensureAsync[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]):
-      Pull[F2, Nothing, AsyncStep[F2,A2]] = Pull.or(
-        self.awaitAsync(Sub1.substHandle(h)),
-        Pull.pure[AsyncStep[F2,A2]](Async.Future.pure(Pull.done))
-      )
-    def ensure1Async[F2[_],A2>:A](implicit S: Sub1[F,F2], F2: Async[F2], A2: RealSupertype[A,A2]):
-      Pull[F2, Nothing, AsyncStep1[F2,A2]] = Pull.or(
-        self.await1Async(Sub1.substHandle(h)),
-        Pull.pure[AsyncStep1[F2,A2]](Async.Future.pure(Pull.done))
-      )
   }
 
   implicit class HandleSyntax2[F[_],+A](h: Handle[F,A]) {
@@ -100,10 +90,6 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
       Pull[F, Nothing, AsyncStep1[F,A2]] = self.await1Async(h)
     def invAwaitAsync[A2>:A](implicit F: Async[F], A2: RealSupertype[A,A2]):
       Pull[F, Nothing, AsyncStep[F,A2]] = self.awaitAsync(h)
-    def invEnsureAsync[A2>:A](implicit F: Async[F], A2: RealSupertype[A,A2]):
-      Pull[F, Nothing, AsyncStep[F,A2]] = h.ensureAsync
-    def invEnsure1Async[A2>:A](implicit F: Async[F], A2: RealSupertype[A,A2]):
-      Pull[F, Nothing, AsyncStep1[F,A2]] = h.ensure1Async
   }
 
   implicit class PullSyntax[F[_],A](s: Stream[F,A]) {

--- a/src/main/scala/fs2/StreamOps.scala
+++ b/src/main/scala/fs2/StreamOps.scala
@@ -48,4 +48,13 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
 
   def runLog: Free[F,Vector[A]] =
     Stream.runFold(self, Vector.empty[A])(_ :+ _)
+
+  def tee[F2[_],B,C](s2: Stream[F2,B])(f: (Handle[F2,A], Handle[F2,B]) => Pull[F2,C,Any])(implicit S: Sub1[F,F2]): Stream[F2,C] =
+    (Sub1.substStream(self)).open.flatMap {
+      h1 => s2.open.flatMap { h2 => f(h1,h2) }
+    }.run
+
+  @deprecated("use `tee`, which now subsumes the functionality of `wye`", "0.9")
+  def wye[F2[_],B,C](s2: Stream[F2,B])(f: (Handle[F2,A], Handle[F2,B]) => Pull[F2,C,Any])(implicit S: Sub1[F,F2]): Stream[F2,C] =
+    tee(s2)(f)
 }

--- a/src/main/scala/fs2/StreamOps.scala
+++ b/src/main/scala/fs2/StreamOps.scala
@@ -24,11 +24,19 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
   def covary[F2[_]](implicit S: Sub1[F,F2]): Stream[F2,A] =
     Sub1.substStream(self)
 
+  /** Alias for `[[concurrent.either]](self, s2)`. */
+  def either[F2[_]:Async,B](s2: Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,Either[A,B]] =
+    concurrent.either(Sub1.substStream(self), s2)
+
   def flatMap[F2[_],B](f: A => Stream[F2,B])(implicit S: Sub1[F,F2]): Stream[F2,B] =
     Stream.flatMap(Sub1.substStream(self))(f)
 
   def map[B](f: A => B): Stream[F,B] =
     Stream.map(self)(f)
+
+  /** Alias for `[[concurrent.merge]](self, s2)`. */
+  def merge[F2[_]:Async,B>:A](s2: Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,B] =
+    concurrent.merge(Sub1.substStream(self), s2)
 
   def onError[F2[_],B>:A](f: Throwable => Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,B] =
     Stream.onError(Sub1.substStream(self): Stream[F2,B])(f)

--- a/src/main/scala/fs2/Streams.scala
+++ b/src/main/scala/fs2/Streams.scala
@@ -52,6 +52,7 @@ trait Streams[Stream[+_[_],+_]] { self =>
 
   def awaitAsync[F[_],A](h: Handle[F,A])(implicit F: Async[F]): Pull[F, Nothing, AsyncStep[F,A]]
 
+  /** Open a `Stream` for transformation. Guaranteed to return a non-`done` `Pull`. */
   def open[F[_],A](s: Stream[F,A]): Pull[F,Nothing,Handle[F,A]]
 
   // evaluation

--- a/src/main/scala/fs2/Wye.scala
+++ b/src/main/scala/fs2/Wye.scala
@@ -8,6 +8,18 @@ import fs2.{Pull => P}
 object wye {
 
   // type Wye[I,I2,+O] = ???
+  // type Wye[F[_],I,I2,+O] =
+  // s.interrupt(interruptSignal)
+  // s.wye(s2)(wye.merge)
+
+  // trait Wye[-I,-I2,+O] {
+  //   def run[F[_]:Async](s: Stream[F,I], s2: Stream[F,I2]): Stream[F,O]
+  // }
+
+  /** Like `[[merge]]`, but tags each output with the branch it came from. */
+  def either[F[_]:Async,O,O2](s1: Handle[F,O], s2: Handle[F,O2])
+    : Pull[F, Either[O,O2], (Handle[F,Either[O,O2]],Handle[F,Either[O,O2]])]
+    = merge(s1.map(Left(_)), s2.map(Right(_)))
 
   /**
    * Interleave the two inputs nondeterministically. The output stream
@@ -23,13 +35,15 @@ object wye {
       (l race r).force flatMap {
         case Left(l) => l.optional flatMap {
           case None => r.force.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
-          case Some(hd #: l) => P.output(hd) >> l.awaitAsync.flatMap(go(_, r))
+          case Some(hd #: l) => P.output(hd) >> l.ensureAsync.flatMap(go(_, r))
         }
         case Right(r) => r.optional flatMap {
           case None => l.force.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
-          case Some(hd #: r) => P.output(hd) >> r.awaitAsync.flatMap(go(l, _))
+          case Some(hd #: r) => P.output(hd) >> r.ensureAsync.flatMap(go(l, _))
         }
       }
-    s1.awaitAsync.flatMap { l => s2.awaitAsync.flatMap { r => go(l,r) }}
+    // todo: awaitAsync can fail immediately, either change that or account for it here
+    // introduce another function on handle - demandAsync defined as awaitAsync.or(...)
+    s1.ensureAsync.flatMap { l => s2.ensureAsync.flatMap { r => go(l,r) }}
   }
 }

--- a/src/main/scala/fs2/Wye.scala
+++ b/src/main/scala/fs2/Wye.scala
@@ -35,15 +35,13 @@ object wye {
       (l race r).force flatMap {
         case Left(l) => l.optional flatMap {
           case None => r.force.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
-          case Some(hd #: l) => P.output(hd) >> l.ensureAsync.flatMap(go(_, r))
+          case Some(hd #: l) => P.output(hd) >> l.awaitAsync.flatMap(go(_, r))
         }
         case Right(r) => r.optional flatMap {
           case None => l.force.flatMap(identity).flatMap { case hd #: tl => P.output(hd) >> P.echo(tl) }
-          case Some(hd #: r) => P.output(hd) >> r.ensureAsync.flatMap(go(l, _))
+          case Some(hd #: r) => P.output(hd) >> r.awaitAsync.flatMap(go(l, _))
         }
       }
-    // todo: awaitAsync can fail immediately, either change that or account for it here
-    // introduce another function on handle - demandAsync defined as awaitAsync.or(...)
-    s1.ensureAsync.flatMap { l => s2.ensureAsync.flatMap { r => go(l,r) }}
+    s1.awaitAsync.flatMap { l => s2.awaitAsync.flatMap { r => go(l,r) }}
   }
 }

--- a/src/main/scala/fs2/concurrent.scala
+++ b/src/main/scala/fs2/concurrent.scala
@@ -12,13 +12,13 @@ object concurrent {
    * Calls `open` on the two streams, then invokes `[[wye.either]]`.
    */
   def either[F[_]:Async,O,O2](s1: Stream[F,O], s2: Stream[F,O2]): Stream[F,Either[O,O2]] =
-    P.run { s1.open.flatMap(h1 => s2.open.flatMap(h2 => wye.either(h1,h2))) }
+    P.run { s1.open.flatMap(h1 => s2.open.flatMap(h2 => wye.either.apply(h1,h2))) }
 
   /**
    * Calls `open` on the two streams, then invokes `[[wye.merge]]`.
    */
   def merge[F[_]:Async,O](s1: Stream[F,O], s2: Stream[F,O]): Stream[F,O] =
-    P.run { s1.open.flatMap(h1 => s2.open.flatMap(h2 => wye.merge(h1,h2))) }
+    P.run { s1.open.flatMap(h1 => s2.open.flatMap(h2 => wye.merge.apply(h1,h2))) }
 
   def join[F[_],O](maxOpen: Int)(s: Stream[F,Stream[F,O]])(implicit F: Async[F]): Stream[F,O] = {
     if (maxOpen <= 0) throw new IllegalArgumentException("maxOpen must be > 0, was: " + maxOpen)

--- a/src/main/scala/fs2/concurrent.scala
+++ b/src/main/scala/fs2/concurrent.scala
@@ -14,7 +14,7 @@ object concurrent {
   def merge[F[_]:Async,O](s1: Stream[F,O], s2: Stream[F,O]): Stream[F,O] =
     P.run { s1.open.flatMap(h1 => s2.open.flatMap(h2 => wye.merge(h1,h2))) }
 
-  def join[F[_]:Async,O](maxOpen: Int)(s: Stream[F,Stream[F,O]]): Stream[F,O] = {
+  def join[F[_],O](maxOpen: Int)(s: Stream[F,Stream[F,O]])(implicit F: Async[F]): Stream[F,O] = {
     if (maxOpen <= 0) throw new IllegalArgumentException("maxOpen must be > 0, was: " + maxOpen)
     def go(s: Handle[F,Stream[F,O]],
            onlyOpen: Boolean, // `true` if `s` should be ignored
@@ -22,44 +22,51 @@ object concurrent {
     : Pull[F,O,Unit] =
       // A) Nothing's open; block to obtain a new open stream
       if (open.isEmpty) s.await1.flatMap { case sh #: s =>
-        sh.open.flatMap(_.await).flatMap { step =>
-          go(s, onlyOpen, open :+ Future.pure(P.pure(step): Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]]))
-      }}
+        sh.open.optional.flatMap {
+          case None => go(s, onlyOpen, open)
+          case Some(sh) => sh.await.optional.flatMap {
+            case Some(step) =>
+              go(s, onlyOpen, open :+ Future.pure(P.pure(step): Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]]))
+            case None => go(s, onlyOpen, open)
+          }
+        }
+      }
       // B) We have too many things open, or `s` is exhausted so we only consult `open`
       // race to obtain a step from each of the currently open handles
-      else if (open.size >= maxOpen || onlyOpen)
+      else if (open.size >= maxOpen || onlyOpen) {
         Future.race(open).force.flatMap { winner =>
           winner.get.optional.flatMap {
             case None => go(s, onlyOpen, winner.delete) // winning `Pull` is done, remove it
             case Some(out #: h) =>
               // winner has more values, write these to output
               // and update the handle for the winning position
-              P.output(out) >> h.awaitAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
+              P.output(out) >> h.ensureAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
           }
         }
+      }
       // C) Like B), but we are allowed to open more handles, so race opening a new handle
       // with pulling from already open handles
       else for {
-        nextS <- s.await1Async
+        nextS <- s.ensure1Async
         elementOrNewStream <- Future.race(open).race(nextS).force
-        _ <- elementOrNewStream match {
+        u <- elementOrNewStream match {
           case Left(winner) => winner.get.optional.flatMap {
             case None => go(s, onlyOpen, winner.delete)
             case Some(out #: h) =>
-              P.output(out) >> h.awaitAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
+              P.output(out) >> h.ensureAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
           }
           case Right(anotherOpen) =>
             anotherOpen.optional.flatMap {
               case Some(s2) => s2 match {
                 case None #: s => go(s, true, open)
                 case Some(s2) #: s => s2.open.flatMap { h2 =>
-                  h2.awaitAsync.map(f => go(s, onlyOpen, open :+ f))
+                  h2.ensureAsync.flatMap { f => go(s, onlyOpen, open :+ f) }
                 }
               }
               case None => go(s, true, open)
             }
         }
-      } yield ()
+      } yield u
     s.open.flatMap { h => go(h, false, Vector.empty) }.run
   }
 }

--- a/src/main/scala/fs2/concurrent.scala
+++ b/src/main/scala/fs2/concurrent.scala
@@ -9,6 +9,12 @@ import fs2.{Pull => P}
 object concurrent {
 
   /**
+   * Calls `open` on the two streams, then invokes `[[wye.either]]`.
+   */
+  def either[F[_]:Async,O,O2](s1: Stream[F,O], s2: Stream[F,O2]): Stream[F,Either[O,O2]] =
+    P.run { s1.open.flatMap(h1 => s2.open.flatMap(h2 => wye.either(h1,h2))) }
+
+  /**
    * Calls `open` on the two streams, then invokes `[[wye.merge]]`.
    */
   def merge[F[_]:Async,O](s1: Stream[F,O], s2: Stream[F,O]): Stream[F,O] =
@@ -22,14 +28,11 @@ object concurrent {
     : Pull[F,O,Unit] =
       // A) Nothing's open; block to obtain a new open stream
       if (open.isEmpty) s.await1.flatMap { case sh #: s =>
-        sh.open.optional.flatMap {
+        sh.open.flatMap { sh => sh.await.optional.flatMap {
+          case Some(step) =>
+            go(s, onlyOpen, open :+ Future.pure(P.pure(step): Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]]))
           case None => go(s, onlyOpen, open)
-          case Some(sh) => sh.await.optional.flatMap {
-            case Some(step) =>
-              go(s, onlyOpen, open :+ Future.pure(P.pure(step): Pull[F,Nothing,Step[Chunk[O],Handle[F,O]]]))
-            case None => go(s, onlyOpen, open)
-          }
-        }
+        }}
       }
       // B) We have too many things open, or `s` is exhausted so we only consult `open`
       // race to obtain a step from each of the currently open handles
@@ -40,27 +43,27 @@ object concurrent {
             case Some(out #: h) =>
               // winner has more values, write these to output
               // and update the handle for the winning position
-              P.output(out) >> h.ensureAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
+              P.output(out) >> h.awaitAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
           }
         }
       }
       // C) Like B), but we are allowed to open more handles, so race opening a new handle
       // with pulling from already open handles
       else for {
-        nextS <- s.ensure1Async
+        nextS <- s.await1Async
         elementOrNewStream <- Future.race(open).race(nextS).force
         u <- elementOrNewStream match {
           case Left(winner) => winner.get.optional.flatMap {
             case None => go(s, onlyOpen, winner.delete)
             case Some(out #: h) =>
-              P.output(out) >> h.ensureAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
+              P.output(out) >> h.awaitAsync.flatMap { next => go(s, onlyOpen, winner.replace(next)) }
           }
           case Right(anotherOpen) =>
             anotherOpen.optional.flatMap {
               case Some(s2) => s2 match {
                 case None #: s => go(s, true, open)
                 case Some(s2) #: s => s2.open.flatMap { h2 =>
-                  h2.ensureAsync.flatMap { f => go(s, onlyOpen, open :+ f) }
+                  h2.awaitAsync.flatMap { f => go(s, onlyOpen, open :+ f) }
                 }
               }
               case None => go(s, true, open)

--- a/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/src/test/scala/fs2/ConcurrentSpec.scala
@@ -1,0 +1,58 @@
+package fs2
+
+import TestUtil._
+import fs2.util.Task
+import fs2.Stream.Handle
+import java.util.concurrent.atomic.AtomicLong
+import org.scalacheck.Prop._
+import org.scalacheck._
+
+object ConcurrentSpec extends Properties("concurrent") {
+
+  val x = implicitly[Strategy]
+
+  property("either") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+    val shouldCompile = s1.get.either(s2.get.covary[Task])
+    val es = run { s1.get.covary[Task].pull2(s2.get.covary[Task])(wye.either) }
+    (es.collect { case Left(i) => i } ?= run(s1.get)) &&
+    (es.collect { case Right(i) => i } ?= run(s2.get))
+  }
+
+  property("merge") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+    run { concurrent.merge(s1.get.covary[Task], s2.get.covary[Task]) }.toSet ?=
+    (run(s1.get).toSet ++ run(s2.get).toSet)
+  }
+
+  property("merge (left/right identity)") = forAll { (s1: PureStream[Int]) =>
+    (run { s1.get.merge(Stream.empty.covary[Task]) } ?= run(s1.get)) &&
+    (run { Stream.empty.pull2(s1.get.covary[Task])(wye.merge[Task,Int]) } ?= run(s1.get))
+  }
+
+  property("merge/join consistency") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
+    run { s1.get.covary[Task].pull2(s2.get.covary[Task])(wye.merge[Task,Int]) }.toSet ?=
+    run { concurrent.join[Task,Int](2)(Stream(s1.get.covary[Task], s2.get.covary[Task])) }.toSet
+  }
+
+  property("join (1)") = forAll { (s1: PureStream[Int]) =>
+    run { concurrent.join(1)(s1.get.covary[Task].map(Stream.emit)) } ?= run { s1.get }
+  }
+
+  property("join (2)") = forAll { (s1: PureStream[Int], n: SmallPositive) =>
+    run { concurrent.join(n.get)(s1.get.covary[Task].map(Stream.emit)) }.toSet ?=
+    run { s1.get }.toSet
+  }
+
+  property("join (3)") = forAll { (s1: PureStream[PureStream[Int]], n: SmallPositive) =>
+    run { concurrent.join(n.get)(s1.get.map(_.get.covary[Task]).covary[Task]) }.toSet ?=
+    run { s1.get.flatMap(_.get) }.toSet
+  }
+
+  property("merge (left/right failure)") = forAll { (s1: PureStream[Int], f: Failure) =>
+    try { run (s1.get merge f.get); false }
+    catch { case Err => true }
+  }
+
+  //property("join (failure 1)") = forAll { (s: PureStream[Failure], n: SmallPositive, f: Failure) =>
+  //  run { concurrent.join(n.get)(s.get) }
+  //}
+}

--- a/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -118,9 +118,4 @@ object ResourceSafetySpec extends Properties("ResourceSafety") {
     Stream.bracket(Task.delay { c.decrementAndGet; println("decrement " + c.get) })(
       _ => s,
       _ => Task.delay { c.incrementAndGet; println("increment " + c.get) })
-
-  /*
-  concurrent.join
-  using generated resources
-  */
 }

--- a/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -28,6 +28,13 @@ object ResourceSafetySpec extends Properties("ResourceSafety") {
     f.tag |: 0L =? c.get
   }
 
+  property("bracket ++ throw Err") = forAll { (s: PureStream[Int]) =>
+    val c = new AtomicLong(0)
+    val b = bracket(c)(s.get ++ ((throw Err): Stream[Pure,Int]))
+    swallow { b }
+    c.get ?= 0
+  }
+
   property("1 million brackets in sequence") = secure {
     val c = new AtomicLong(0)
     val b = bracket(c)(Stream.emit(1))

--- a/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -89,11 +89,23 @@ object ResourceSafetySpec extends Properties("ResourceSafety") {
     c.get ?= 0L
   }
 
+  property("asynchronous resource allocation (3)") = forAll {
+    (s: PureStream[(PureStream[Int], Option[Failure])]
+    , allowFailure: Boolean, f: Failure, n: SmallPositive) =>
+    val c = new AtomicLong(0)
+    val s2 = bracket(c)(s.get.map { case (s, f) =>
+      if (allowFailure) f.map(f => spuriousFail(bracket(c)(s.get), f)).getOrElse(bracket(c)(s.get))
+      else bracket(c)(s.get)
+    })
+    swallow { run { concurrent.join(n.get)(s2) }}
+    c.get ?= 0L
+  }
+
   def swallow(a: => Any): Unit =
     try { a; () }
     catch { case e: Throwable => () }
 
-  def bracket(c: AtomicLong)(s: Stream[Task,Int]): Stream[Task,Int] =
+  def bracket[A](c: AtomicLong)(s: Stream[Task,A]): Stream[Task,A] =
     Stream.bracket(Task.delay(c.decrementAndGet))(_ => s, _ => Task.delay(c.incrementAndGet))
   def lbracket(c: AtomicLong)(s: Stream[Task,Int]): Stream[Task,Int] =
     Stream.bracket(Task.delay { c.decrementAndGet; println("decrement " + c.get) })(


### PR DESCRIPTION
Okay, I feel like the resource safety tests are in a pretty good place, and AFAICT all the ones that are still relevant from the old codebase have been ported over or are covered by more general scalacheck scenarios.

This PR also includes tests for `merge` and `concurrent.join` operators, which are used in the resource safety tests (so this tests for asynchronous resource allocation). Scalacheck found a couple bugs with the implementations of these.

When this is merged I'm planning on closing #442. Of course, if anyone comes up with new things to test for later, we can still add them. :)