### PR TITLE
Switch to new and improved representation of `Process1`, `Tee`, and `Wye`

### DIFF
--- a/src/main/scala/fs2/Process1Ops.scala
+++ b/src/main/scala/fs2/Process1Ops.scala
@@ -1,5 +1,7 @@
 package fs2
 
+import fs2.util.Sub1
+
 trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
 
   // note: these are in alphabetical order
@@ -15,10 +17,10 @@ trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
 
   /** Alias for `self pipe [[process1.drop]]`. */
   def drop(n: Int): Stream[F,O] = self pipe process1.drop(n)
-  
+
   /** Alias for `self pipe [[process1.dropWhile]]` */
   def dropWhile(p: O => Boolean): Stream[F,O] = self pipe process1.dropWhile(p)
-  
+
   /** Alias for `self pipe [[process1.filter]]`. */
   def filter(f: O => Boolean): Stream[F,O] = self pipe process1.filter(f)
 
@@ -48,13 +50,13 @@ trait Process1Ops[+F[_],+O] { self: Stream[F,O] =>
 
   /** Alias for `self pipe [[process1.take]](n)`. */
   def take(n: Long): Stream[F,O] = self pipe process1.take(n)
-  
+
   /** Alias for `self pipe [[process1.takeWhile]]`. */
   def takeWhile(p: O => Boolean): Stream[F,O] = self pipe process1.takeWhile(p)
- 
+
   /** Alias for `self pipe [[process1.unchunk]]`. */
   def unchunk: Stream[F,O] = self pipe process1.unchunk
-  
+
   /** Alias for `self pipe [[process1.zipWithIndex]]` .*/
   def zipWithIndex: Stream[F, (O, Int)] = self pipe process1.zipWithIndex
 }

--- a/src/main/scala/fs2/PullOps.scala
+++ b/src/main/scala/fs2/PullOps.scala
@@ -27,4 +27,7 @@ trait PullOps[+F[_],+W,+R] { self: Pull[F,W,R] =>
   /** Defined as `p >> p2 == p flatMap { _ => p2 }`. */
   def >>[F2[x]>:F[x],W2>:W,R2](p2: => Pull[F2,W2,R2])(implicit S: RealSupertype[W,W2])
   : Pull[F2,W2,R2] = self flatMap { _ => p2 }
+
+  /** Definition: `p as r == p map (_ => r)`. */
+  def as[R2](r: R2): Pull[F,W,R2] = self map (_ => r)
 }

--- a/src/main/scala/fs2/Strategy.scala
+++ b/src/main/scala/fs2/Strategy.scala
@@ -1,6 +1,6 @@
 package fs2
 
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executor
 import scala.concurrent.ExecutionContext
 
 /** Provides a function for evaluating thunks, possibly asynchronously. */
@@ -17,7 +17,7 @@ object Strategy {
   }
 
   /** Create a `Strategy` from an `ExecutionContext`. */
-  def fromExecutionContext(es: ExecutorService): Strategy = new Strategy {
+  def fromExecutor(es: Executor): Strategy = new Strategy {
     def apply(thunk: => Unit): Unit =
       es.execute { new Runnable { def run = thunk } }
   }

--- a/src/main/scala/fs2/StreamDerived.scala
+++ b/src/main/scala/fs2/StreamDerived.scala
@@ -92,11 +92,15 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
       Pull[F, Nothing, AsyncStep[F,A2]] = self.awaitAsync(h)
   }
 
-  implicit class PullSyntax[F[_],A](s: Stream[F,A]) {
+  implicit class InvariantSyntax[F[_],A](s: Stream[F,A]) {
+    def through[B](f: Stream[F,A] => Stream[F,B]): Stream[F,B] = f(s)
+    def to[B](f: Stream[F,A] => Stream[F,Unit]): Stream[F,Unit] = f(s)
     def pull[B](using: Handle[F,A] => Pull[F,B,Any]): Stream[F,B] =
       Stream.pull(s)(using)
     def pull2[B,C](s2: Stream[F,B])(using: (Handle[F,A], Handle[F,B]) => Pull[F,C,Any]): Stream[F,C] =
       s.open.flatMap { h1 => s2.open.flatMap { h2 => using(h1,h2) }}.run
+    def pipe2[B,C](s2: Stream[F,B])(f: (Stream[F,A], Stream[F,B]) => Stream[F,C]): Stream[F,C] =
+      f(s,s2)
     def repeatPull[B](using: Handle[F,A] => Pull[F,B,Handle[F,A]]): Stream[F,B] =
       Stream.repeatPull(s)(using)
   }

--- a/src/main/scala/fs2/StreamDerived.scala
+++ b/src/main/scala/fs2/StreamDerived.scala
@@ -97,6 +97,8 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
       Stream.pull(s)(using)
     def pull2[B,C](s2: Stream[F,B])(using: (Handle[F,A], Handle[F,B]) => Pull[F,C,Any]): Stream[F,C] =
       s.open.flatMap { h1 => s2.open.flatMap { h2 => using(h1,h2) }}.run
+    def repeatPull[B](using: Handle[F,A] => Pull[F,B,Handle[F,A]]): Stream[F,B] =
+      Stream.repeatPull(s)(using)
   }
 
   implicit def covaryPure[F[_],A](s: Stream[Pure,A]): Stream[F,A] = s.covary[F]

--- a/src/main/scala/fs2/StreamOps.scala
+++ b/src/main/scala/fs2/StreamOps.scala
@@ -43,16 +43,13 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
 
   def open: Pull[F, Nothing, Handle[F,A]] = Stream.open(self)
 
-  def pipe[B](f: Process1[_ >: A,B]): Stream[F,B] = self pull process1.covary(f)
+  def pipe[B](f: Process1[A,B]): Stream[F,B] = process1.covary(f)(self)
 
   def pipe2[F2[_],B,C](s2: Stream[F2,B])(f: (Stream[F2,A], Stream[F2,B]) => Stream[F2,C])(implicit S: Sub1[F,F2]): Stream[F2,C] =
     f(Sub1.substStream(self), s2)
 
   def pullv[F2[_],B](using: Handle[F,A] => Pull[F2,B,Any])(implicit S: Sub1[F,F2]): Stream[F2,B] =
     Stream.pull(self)(using)
-
-  def repeatPull[F2[_],A2>:A,B](using: Handle[F2,A2] => Pull[F2,B,Handle[F2,A2]])(implicit S: Sub1[F,F2]): Stream[F2,B] =
-    Stream.repeatPull(Sub1.substStream(self): Stream[F2,A2])(using)
 
   def runFold[B](z: B)(f: (B,A) => B): Free[F,B] =
     Stream.runFold(self, z)(f)

--- a/src/main/scala/fs2/StreamOps.scala
+++ b/src/main/scala/fs2/StreamOps.scala
@@ -26,7 +26,7 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
 
   /** Alias for `[[concurrent.either]](self, s2)`. */
   def either[F2[_]:Async,B](s2: Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,Either[A,B]] =
-    concurrent.either(Sub1.substStream(self), s2)
+    fs2.wye.either.apply(Sub1.substStream(self), s2)
 
   def flatMap[F2[_],B](f: A => Stream[F2,B])(implicit S: Sub1[F,F2]): Stream[F2,B] =
     Stream.flatMap(Sub1.substStream(self))(f)
@@ -36,7 +36,7 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
 
   /** Alias for `[[concurrent.merge]](self, s2)`. */
   def merge[F2[_]:Async,B>:A](s2: Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,B] =
-    concurrent.merge(Sub1.substStream(self), s2)
+    fs2.wye.merge.apply(Sub1.substStream(self), s2)
 
   def onError[F2[_],B>:A](f: Throwable => Stream[F2,B])(implicit R: RealSupertype[A,B], S: Sub1[F,F2]): Stream[F2,B] =
     Stream.onError(Sub1.substStream(self): Stream[F2,B])(f)
@@ -44,6 +44,9 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
   def open: Pull[F, Nothing, Handle[F,A]] = Stream.open(self)
 
   def pipe[B](f: Process1[_ >: A,B]): Stream[F,B] = self pull process1.covary(f)
+
+  def pipe2[F2[_],B,C](s2: Stream[F2,B])(f: (Stream[F2,A], Stream[F2,B]) => Stream[F2,C])(implicit S: Sub1[F,F2]): Stream[F2,C] =
+    f(Sub1.substStream(self), s2)
 
   def pullv[F2[_],B](using: Handle[F,A] => Pull[F2,B,Any])(implicit S: Sub1[F,F2]): Stream[F2,B] =
     Stream.pull(self)(using)
@@ -57,12 +60,11 @@ trait StreamOps[+F[_],+A] extends Process1Ops[F,A] /* with TeeOps[F,A] with WyeO
   def runLog: Free[F,Vector[A]] =
     Stream.runFold(self, Vector.empty[A])(_ :+ _)
 
-  def tee[F2[_],B,C](s2: Stream[F2,B])(f: (Handle[F2,A], Handle[F2,B]) => Pull[F2,C,Any])(implicit S: Sub1[F,F2]): Stream[F2,C] =
-    (Sub1.substStream(self)).open.flatMap {
-      h1 => s2.open.flatMap { h2 => f(h1,h2) }
-    }.run
+  @deprecated("use `pipe2`, which now subsumes the functionality of `wye` and `tee`", "0.9")
+  def tee[F2[_],B,C](s2: Stream[F2,B])(f: (Stream[F2,A], Stream[F2,B]) => Stream[F2,C])(implicit S: Sub1[F,F2])
+  : Stream[F2,C] = pipe2(s2)(f)
 
-  @deprecated("use `tee`, which now subsumes the functionality of `wye`", "0.9")
-  def wye[F2[_],B,C](s2: Stream[F2,B])(f: (Handle[F2,A], Handle[F2,B]) => Pull[F2,C,Any])(implicit S: Sub1[F,F2]): Stream[F2,C] =
-    tee(s2)(f)
+  @deprecated("use `pipe2`, which now subsumes the functionality of `wye` and `tee`", "0.9")
+  def wye[F2[_],B,C](s2: Stream[F2,B])(f: (Stream[F2,A], Stream[F2,B]) => Stream[F2,C])(implicit S: Sub1[F,F2])
+  : Stream[F2,C] = pipe2(s2)(f)
 }

--- a/src/main/scala/fs2/Wye.scala
+++ b/src/main/scala/fs2/Wye.scala
@@ -8,20 +8,26 @@ import fs2.util.NotNothing
 
 object wye {
 
-  // type Wye[I,I2,+O] = ???
-  // type Wye[F[_],I,I2,+O] =
-  // s.interrupt(interruptSignal)
-  // s.wye(s2)(wye.merge)
-
-  // trait Wye[-I,-I2,+O] {
-  //   def run[F[_]:Async](s: Stream[F,I], s2: Stream[F,I2]): Stream[F,O]
-  // }
+  type Wye[F[_],-I,-I2,+O] = (Stream[F,I], Stream[F,I2]) => Stream[F,O]
 
   /** Like `[[merge]]`, but tags each output with the branch it came from. */
-  def either[F[_]:Async,O,O2]
-    : (Handle[F,O], Handle[F,O2]) =>
-      Pull[F, Either[O,O2], (Handle[F,Either[O,O2]],Handle[F,Either[O,O2]])]
-    = (s1, s2) => merge.apply(s1.map(Left(_)), s2.map(Right(_)))
+  def either[F[_]:Async,I,I2]: Wye[F,I,I2,Either[I,I2]] =
+    (s1, s2) => merge.apply(s1.map(Left(_)), s2.map(Right(_)))
+
+  /**
+   * Let through the right branch as long as the left branch is `false`,
+   * listening asynchronously for the left branch to become `true`.
+   * This halts as soon as the right or left branch halts.
+   */
+  //def interrupt[I]: Wye[Boolean, I, I] =
+  //  receiveBoth {
+  //    case ReceiveR(i)    => emit(i) ++ interrupt
+  //    case ReceiveL(kill) => if (kill) halt else interrupt
+  //    case HaltOne(e)     => Halt(e)
+  //  }
+
+  // def interrupt[F[_]:Async,I]: Wye[F,Boolean,I,I] =
+  //  (s1, s2) =>
 
   /**
    * Interleave the two inputs nondeterministically. The output stream
@@ -31,7 +37,7 @@ object wye {
    * eventually terminate with `fail(e)`, possibly after emitting some
    * elements of `s` first.
    */
-  def merge[F[_]:Async,O]: (Handle[F,O], Handle[F,O]) => Pull[F,O,(Handle[F,O],Handle[F,O])] = {
+  def merge[F[_]:Async,O]: Wye[F,O,O,O] = {
     def go(l: Future[F, Pull[F, Nothing, Step[Chunk[O], Handle[F,O]]]],
            r: Future[F, Pull[F, Nothing, Step[Chunk[O], Handle[F,O]]]]): Pull[F,O,Nothing] =
       (l race r).force flatMap {
@@ -44,6 +50,8 @@ object wye {
           case Some(hd #: r) => P.output(hd) >> r.awaitAsync.flatMap(go(l, _))
         }
       }
-    (s1, s2) => s1.awaitAsync.flatMap { l => s2.awaitAsync.flatMap { r => go(l,r) }}
+    _.pull2(_) {
+      (s1,s2) => s1.awaitAsync.flatMap { l => s2.awaitAsync.flatMap { r => go(l,r) }}
+    }
   }
 }

--- a/src/main/scala/fs2/fs2.scala
+++ b/src/main/scala/fs2/fs2.scala
@@ -1,5 +1,11 @@
 package object fs2 {
 
+  type Process1[-I,+O] = process1.Process1[I,O]
+  type Tee[-I,-I2,+O] = tee.Tee[I,I2,O]
+  type Wye[F[_],-I,-I2,+O] = wye.Wye[F,I,I2,O]
+  type Channel[F[_],-I,+O] = Stream[F,I] => Stream[F,O]
+  type Sink[F[_],-I] = Channel[F,I,Unit]
+
   @deprecated("renamed to fs2.Stream", "0.9")
   type Process[+F[_],+O] = Stream[F,O]
   @deprecated("renamed to fs2.Stream", "0.9")

--- a/src/test/scala/fs2/CompilationTest.scala
+++ b/src/test/scala/fs2/CompilationTest.scala
@@ -5,17 +5,19 @@ import fs2.util.Task
 object ThisModuleShouldCompile {
 
   /* Some checks that `.pull` can be used without annotations */
-  val a = Stream(1,2,3,4) pull process1.take(2)
-  val aa: Stream[Nothing,Int] = Stream(1,2,3,4) pull process1.take(2)
-  val a2 = Stream.eval(Task.now(1)) pull process1.take(2)
-  val a3 = Stream(1,2,3,4) pull[Int] process1.take(2)
+  val a = Stream(1,2,3,4) pipe process1.take(2)
+  val aa: Stream[Nothing,Int] = Stream(1,2,3,4) pipe process1.take(2)
+  val a2 = Stream.eval(Task.now(1)) pipe process1.take(2)
+  val a3 = Stream(1,2,3,4) pipe[Int] process1.take(2)
+  val a3a = Stream(1,2,3).covary[Task] pull { h => h.await1 }
+  val a3b = Stream.eval(Task.now(1)) pull { h => h.await1 }
 
   /* Also in a polymorphic context. */
-  def a4[F[_],A](s: Stream[F,A]) = s pull process1.take(2)
-  def a5[F[_],A](s: Stream[F,A]): Stream[F,A] = s pull process1.take(2)
-  def a6[F[_],A](s: Stream[F,A]): Stream[F,A] = s pullv process1.take[F,A](2)
+  def a4[F[_],A](s: Stream[F,A]) = s pipe process1.take(2)
+  def a5[F[_],A](s: Stream[F,A]): Stream[F,A] = s pipe process1.take(2)
+  def a6[F[_],A](s: Stream[F,A]): Stream[F,A] = s pipe process1.take(2)
 
-  val b = process1.take(2)
+  val b = process1.take[Pure,Int](2)
   val c = Stream(1,2,3) ++ Stream(4,5,6)
   val d = Stream(1,2,3) ++ Stream.eval(Task.now(4))
   val e = Stream(1,2,3).flatMap(i => Stream.eval(Task.now(i)))

--- a/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/src/test/scala/fs2/ConcurrentSpec.scala
@@ -13,7 +13,7 @@ object ConcurrentSpec extends Properties("concurrent") {
 
   property("either") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
     val shouldCompile = s1.get.either(s2.get.covary[Task])
-    val es = run { s1.get.pipe2(s2.get.covary[Task])(wye.either) }
+    val es = run { s1.get.covary[Task].pipe2(s2.get)(wye.either) }
     (es.collect { case Left(i) => i } ?= run(s1.get)) &&
     (es.collect { case Right(i) => i } ?= run(s2.get))
   }
@@ -29,7 +29,7 @@ object ConcurrentSpec extends Properties("concurrent") {
   }
 
   property("merge/join consistency") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    run { s1.get.pipe2(s2.get.covary[Task])(wye.merge) }.toSet ?=
+    run { s1.get.pipe2v(s2.get.covary[Task])(wye.merge) }.toSet ?=
     run { concurrent.join(2)(Stream(s1.get.covary[Task], s2.get.covary[Task])) }.toSet
   }
 

--- a/src/test/scala/fs2/ConcurrentSpec.scala
+++ b/src/test/scala/fs2/ConcurrentSpec.scala
@@ -13,24 +13,24 @@ object ConcurrentSpec extends Properties("concurrent") {
 
   property("either") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
     val shouldCompile = s1.get.either(s2.get.covary[Task])
-    val es = run { s1.get.covary[Task].pull2(s2.get.covary[Task])(wye.either) }
+    val es = run { s1.get.pipe2(s2.get.covary[Task])(wye.either) }
     (es.collect { case Left(i) => i } ?= run(s1.get)) &&
     (es.collect { case Right(i) => i } ?= run(s2.get))
   }
 
   property("merge") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    run { concurrent.merge(s1.get.covary[Task], s2.get.covary[Task]) }.toSet ?=
+    run { s1.get.merge(s2.get.covary[Task]) }.toSet ?=
     (run(s1.get).toSet ++ run(s2.get).toSet)
   }
 
   property("merge (left/right identity)") = forAll { (s1: PureStream[Int]) =>
     (run { s1.get.merge(Stream.empty.covary[Task]) } ?= run(s1.get)) &&
-    (run { Stream.empty.pull2(s1.get.covary[Task])(wye.merge[Task,Int]) } ?= run(s1.get))
+    (run { Stream.empty.pipe2(s1.get.covary[Task])(wye.merge) } ?= run(s1.get))
   }
 
   property("merge/join consistency") = forAll { (s1: PureStream[Int], s2: PureStream[Int]) =>
-    run { s1.get.covary[Task].pull2(s2.get.covary[Task])(wye.merge[Task,Int]) }.toSet ?=
-    run { concurrent.join[Task,Int](2)(Stream(s1.get.covary[Task], s2.get.covary[Task])) }.toSet
+    run { s1.get.pipe2(s2.get.covary[Task])(wye.merge) }.toSet ?=
+    run { concurrent.join(2)(Stream(s1.get.covary[Task], s2.get.covary[Task])) }.toSet
   }
 
   property("join (1)") = forAll { (s1: PureStream[Int]) =>

--- a/src/test/scala/fs2/Process1Spec.scala
+++ b/src/test/scala/fs2/Process1Spec.scala
@@ -4,6 +4,7 @@ import fs2.Chunk.{Bits, Bytes, Doubles}
 import fs2.Stream._
 import fs2.TestUtil._
 import fs2.process1._
+import fs2.util.Task
 import org.scalacheck.Prop._
 import org.scalacheck.{Gen, Properties}
 import scodec.bits.{BitVector, ByteVector}
@@ -110,6 +111,10 @@ object Process1Spec extends Properties("process1") {
 
   property("lift") = forAll { (s: PureStream[Double]) =>
     s.get.pipe(lift(_.toString)) ==? run(s.get).map(_.toString)
+  }
+
+  property("prefetch") = forAll { (s: PureStream[Int]) =>
+    s.get.covary[Task].through(prefetch) ==? run(s.get)
   }
 
   property("take") = forAll { (s: PureStream[Int], negate: Boolean, n0: SmallNonnegative) =>

--- a/src/test/scala/fs2/ResourceSafetySpec.scala
+++ b/src/test/scala/fs2/ResourceSafetySpec.scala
@@ -73,8 +73,8 @@ object ResourceSafetySpec extends Properties("ResourceSafety") {
     val c = new AtomicLong(0)
     val b1 = bracket(c)(s1.get)
     val b2 = f1.get
-    swallow { run { concurrent.merge(b1, b2) }}
-    swallow { run { concurrent.merge(b2, b1) }}
+    swallow { run { b1.merge(b2) }}
+    swallow { run { b2.merge(b1) }}
     c.get ?= 0L
   }
 
@@ -83,9 +83,9 @@ object ResourceSafetySpec extends Properties("ResourceSafety") {
     val c = new AtomicLong(0)
     val b1 = bracket(c)(s1.get)
     val b2 = bracket(c)(s1.get)
-    swallow { run { concurrent.merge(spuriousFail(b1,f1), b2) }}
-    swallow { run { concurrent.merge(b1, spuriousFail(b2,f2)) }}
-    swallow { run { concurrent.merge(spuriousFail(b1,f1), spuriousFail(b2,f2)) } }
+    swallow { run { spuriousFail(b1,f1) merge b2 }}
+    swallow { run { b1 merge spuriousFail(b2,f2) }}
+    swallow { run { spuriousFail(b1,f1) merge spuriousFail(b2,f2) }}
     c.get ?= 0L
   }
 

--- a/src/test/scala/fs2/TestUtil.scala
+++ b/src/test/scala/fs2/TestUtil.scala
@@ -15,6 +15,15 @@ object TestUtil {
       case _ => false
     }
 
+  def logTiming[A](msg: String)(a: => A): A = {
+    import scala.concurrent.duration._
+    val start = System.currentTimeMillis
+    val result = a
+    val stop = System.currentTimeMillis
+    println(msg + " took " + (stop-start).milliseconds)
+    result
+  }
+
   implicit class EqualsOp[F[_],A](s: Stream[F,A])(implicit S: Sub1[F,Task]) {
     def ===(v: Vector[A]) = run(s.covary) == v
     def ==?(v: Vector[A]) = {


### PR DESCRIPTION
This PR is built on #475 

Sort of a subtle issue, but with the current representation, you can't invoke a `Stream[F,A] => Stream[F,B]` from within a `Process1`. That's not good for composition. And making `Handle[F,A] => Pull[F,O,R]` the basis for composition doesn't work out well because you can't adjust the output type `O` after the fact. (And changing this would complicate the API and the implementation.)

With the new representation, a `Process1[A,B]` is just a regular function from `Stream[Pure,A] => Stream[Pure,B]`, which can be promoted to a `Stream[F,A] => Stream[F,B]` via `Process1.covary`, or the `pipe` and `pipe2` combinators will automatically do the right thing.

I originally thought this representation would lead to boilerplate, but with the `pull` and `repeatPull` combinators, there's none. The added flexibility means it can pass the input through 20 different pipeline stages and generally build up transducers in a compositional fashion, via transforming streams, and/or using the `Pull` functions directly.

As a bonus, I also got rid of the `NotNothing` stuff. It is no longer needed if the functions are curried the right way.

This PR also moves some functions into `pull1` that previously only existed in `process1`. When you have an already-open stream, these can be useful, and they are also useful when building up a larger `Pull`. The policy I am using is that if a function does not fully consume its input stream(s), consider adding a function to `pull1.scala` or `pull2.scala` that returns the remainder(s). Then have the `process1` function use it. Check out `process1.dropWhile` for an example of this.