### PR TITLE
FS2: Simplify process1.zipWithIndex

### DIFF
--- a/src/main/scala/fs2/Chunk.scala
+++ b/src/main/scala/fs2/Chunk.scala
@@ -49,11 +49,6 @@ trait Chunk[+A] { self =>
     iterator.scanLeft(z)(f).copyToBuffer(buf)
     Chunk.indexedSeq(buf)
   }
-  def zipWithIndex: Chunk[(A, Int)] = {
-    val buf = new collection.mutable.ArrayBuffer[(A, Int)](size)
-    iterator.zipWithIndex.copyToBuffer(buf)
-    Chunk.indexedSeq(buf)
-  }
   def iterator: Iterator[A] = new Iterator[A] {
     var i = 0
     def hasNext = i < self.size

--- a/src/main/scala/fs2/Process1.scala
+++ b/src/main/scala/fs2/Process1.scala
@@ -164,12 +164,9 @@ object process1 {
 
   /** Zip the elements of the input `Handle `with its indices, and return the new `Handle` */
   def zipWithIndex[F[_],I]: Stream[F,I] => Stream[F,(I,Int)] = {
-    def go(n: Int): Handle[F, I] => Pull[F, (I, Int), Handle[F, I]] = {
-      Pull.receive { case chunk #: h =>
-        Pull.output(chunk.zipWithIndex.map({ case (c, i) => (c, i + n) })) >> go(n + chunk.size)(h)
-      }
-    }
-    _ pull (go(0))
+    mapAccumulate[F, Int, I, I](-1) {
+      case (i, x) => (i + 1, x)
+    } andThen(_.map(_.swap))
   }
 
   // stepping a process


### PR DESCRIPTION
Implement `process1.zipWithNext` in terms of `process1.mapAccumulate`, so we don't need `Chunk#zipWithNext`.