### PR TITLE
Renamed implicit classes defining operators to match pattern ...Ops

### DIFF
--- a/src/main/scala/fs2/Stream.scala
+++ b/src/main/scala/fs2/Stream.scala
@@ -3,7 +3,6 @@ package fs2
 import collection.immutable.LongMap
 import fs2.internal.Trampoline
 import fs2.util._
-import fs2.util.UF1.{~>}
 import fs2.Async.Future
 
 /**

--- a/src/main/scala/fs2/StreamDerived.scala
+++ b/src/main/scala/fs2/StreamDerived.scala
@@ -69,7 +69,7 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
   def peek1[F[_],A](h: Handle[F,A]): Pull[F, Nothing, Step[A, Handle[F,A]]] =
     h.await1 flatMap { case hd #: tl => Pull.pure(hd #: tl.push1(hd)) }
 
-  implicit class HandleSyntax[+F[_],+A](h: Handle[F,A]) {
+  implicit class HandleOps[+F[_],+A](h: Handle[F,A]) {
     def push[A2>:A](c: Chunk[A2])(implicit A2: RealSupertype[A,A2]): Handle[F,A2] =
       self.push(h: Handle[F,A2])(c)
     def push1[A2>:A](a: A2)(implicit A2: RealSupertype[A,A2]): Handle[F,A2] =
@@ -85,14 +85,14 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
       Pull[F2, Nothing, AsyncStep1[F2,A2]] = self.await1Async(Sub1.substHandle(h))
   }
 
-  implicit class HandleSyntax2[F[_],+A](h: Handle[F,A]) {
+  implicit class HandleInvariantEffectOps[F[_],+A](h: Handle[F,A]) {
     def invAwait1Async[A2>:A](implicit F: Async[F], A2: RealSupertype[A,A2]):
       Pull[F, Nothing, AsyncStep1[F,A2]] = self.await1Async(h)
     def invAwaitAsync[A2>:A](implicit F: Async[F], A2: RealSupertype[A,A2]):
       Pull[F, Nothing, AsyncStep[F,A2]] = self.awaitAsync(h)
   }
 
-  implicit class InvariantSyntax[F[_],A](s: Stream[F,A]) {
+  implicit class StreamInvariantOps[F[_],A](s: Stream[F,A]) {
     def through[B](f: Stream[F,A] => Stream[F,B]): Stream[F,B] = f(s)
     def to[B](f: Stream[F,A] => Stream[F,Unit]): Stream[F,Unit] = f(s)
     def pull[B](using: Handle[F,A] => Pull[F,B,Any]): Stream[F,B] =
@@ -105,7 +105,7 @@ private[fs2] trait StreamDerived { self: fs2.Stream.type =>
       Stream.repeatPull(s)(using)
   }
 
-  implicit class PureStreamSyntax[+A](s: Stream[Pure,A]) {
+  implicit class StreamPureOps[+A](s: Stream[Pure,A]) {
     def toList: List[A] =
       s.covary[Task].runFold(List.empty[A])((b, a) => a :: b).run.run.reverse
     def toVector: Vector[A] = s.covary[Task].runLog.run.run

--- a/src/main/scala/fs2/Streams.scala
+++ b/src/main/scala/fs2/Streams.scala
@@ -2,7 +2,7 @@ package fs2
 
 import Step.{#:}
 import fs2.util.{Free,NotNothing}
-import fs2.util.UF1.{~>}
+import fs2.util.~>
 
 trait Streams[Stream[+_[_],+_]] { self =>
 

--- a/src/main/scala/fs2/util/Free.scala
+++ b/src/main/scala/fs2/util/Free.scala
@@ -1,6 +1,5 @@
 package fs2.util
 
-import fs2.util.UF1._
 import fs2.internal.Trampoline
 
 sealed trait Free[+F[_],+A] {
@@ -21,7 +20,7 @@ sealed trait Free[+F[_],+A] {
   : Trampoline[Unroll[A, G[Free[F,A]]]]
 
   def run[F2[x]>:F[x], A2>:A](implicit F2: Catchable[F2]): F2[A2] =
-    (this: Free[F2,A2]).runTranslate(id)
+    (this: Free[F2,A2]).runTranslate(UF1.id)
 
   @annotation.tailrec
   private[fs2] final def step: Free[F,A] = this match {

--- a/src/main/scala/fs2/util/UF1.scala
+++ b/src/main/scala/fs2/util/UF1.scala
@@ -4,7 +4,5 @@ package fs2.util
 trait UF1[-F[_],+G[_]] { def apply[A](f: F[A]): G[A] }
 
 object UF1 {
-  type ~>[-F[_],+G[_]] = UF1[F,G]
-
-  def id[F[_]]: (F ~> F) = new UF1[F,F] { def apply[A](f: F[A]) = f }
+  def id[F[_]]: (F ~> F) = new UF1[F, F] { def apply[A](f: F[A]) = f }
 }

--- a/src/main/scala/fs2/util/util.scala
+++ b/src/main/scala/fs2/util/util.scala
@@ -1,6 +1,9 @@
 package fs2
 
 package object util {
+
+  type ~>[F[_], G[_]] = UF1[F, G]
+
   type NotNothing[F[_]] = Sub1[F,F]
 
   def notNothing[F[_]]: NotNothing[F] = Sub1.sub1[F]


### PR DESCRIPTION
…and moved type alias for UF1 to util package object.

Not a huge fan of some of the names but I used 2 rules when choosing them:
 - must end in `Ops`
 - must start with the name of the class that's being decorated

These rules are designed to simplify source navigation in symbol aware text editors.