### PR TITLE
Point wiki link to fs2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The library supports a number of other interesting use cases:
 
 ### Documentation and getting help ###
 
-There are examples (with commentary) in the test directory [`scalaz.stream.examples`](https://github.com/scalaz/scalaz-stream/tree/master/src/test/scala/scalaz/stream/examples). Also see [the wiki](https://github.com/scalaz/scalaz-stream/wiki) for more documentation. If you use `scalaz.stream`, you're strongly encouraged to submit additional examples and add to the wiki!
+There are examples (with commentary) in the test directory [`scalaz.stream.examples`](https://github.com/scalaz/scalaz-stream/tree/master/src/test/scala/scalaz/stream/examples). Also see [the fs2 wiki](https://github.com/functional-streams-for-scala/fs2/wiki/Additional-Resources) for more documentation. If you use `scalaz.stream`, you're strongly encouraged to submit additional examples and add to the wiki!
 
 For questions about the library, use the [scalaz mailing list](https://groups.google.com/forum/#!forum/scalaz) or the [scalaz-stream tag on StackOverflow](http://stackoverflow.com/questions/tagged/scalaz-stream).
 


### PR DESCRIPTION
Seems the wiki for scalaz-stream has been removed, so this link simply comes back to this readme. I don't know the exact history here, but seems the fs2 wiki is a good place to send folks.
